### PR TITLE
[AICH-61] feat : 사용자 프롬프트로, 추가적인 질문/답변 1개 생성

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -19,6 +19,13 @@
         </processorPath>
         <module name="cvmento.main" />
       </profile>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
+        </processorPath>
+        <module name="cvmento.test" />
+      </profile>
     </annotationProcessing>
   </component>
   <component name="JavacSettings">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/AIBE2_FinalProject_CodeHansabari_BE.iml" filepath="$PROJECT_DIR$/.idea/AIBE2_FinalProject_CodeHansabari_BE.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/cvmento.main.iml" filepath="$PROJECT_DIR$/.idea/modules/cvmento.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/cvmento.test.iml" filepath="$PROJECT_DIR$/.idea/modules/cvmento.test.iml" />
     </modules>
   </component>
 </project>

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/repository/CoverLetterRepository.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/repository/CoverLetterRepository.java
@@ -5,6 +5,8 @@ import com.cvmento.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +18,8 @@ public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> 
     // 페이징 지원 메서드들
     Page<CoverLetter> findByMemberOrderByUpdatedAtDesc(Member member, Pageable pageable);
     Optional<CoverLetter> findByCoverLetterIdAndMember(Long coverLetterId, Member member);
+
+    @Query("SELECT c FROM CoverLetter c WHERE c.coverLetterId = :coverLetterId AND c.member.email = :userEmail")
+    Optional<CoverLetter> findByCoverLetterIdAndMemberEmail(@Param("coverLetterId") Long coverLetterId,
+                                                            @Param("userEmail") String userEmail);
 }

--- a/CVMento/src/main/java/com/cvmento/domain/interview/controller/InterviewController.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/controller/InterviewController.java
@@ -1,5 +1,7 @@
 package com.cvmento.domain.interview.controller;
 
+import com.cvmento.domain.interview.dto.request.CustomQuestionRequest;
+import com.cvmento.domain.interview.dto.response.CustomAnswerResponse;
 import com.cvmento.domain.interview.dto.response.InterviewQnaListResponse;
 import com.cvmento.domain.interview.service.InterviewService;
 import com.cvmento.global.common.dto.CommonResponse;
@@ -10,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -181,7 +184,86 @@ public class InterviewController {
     }
 
     /**
-     * 사용자 질문에 따른 ai 답변 생성 ( 답변은 1개이며, 갯수 상관없이 답변 )
+     * 사용자 커스텀 질문에 대한 AI 답변 생성
      */
+    @Operation(
+            summary = "커스텀 질문 AI 답변 생성",
+            description = "사용자가 직접 입력한 질문에 대해 자소서를 기반으로 한 AI 답변을 생성합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "답변 생성 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = CommonResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "답변 생성 성공",
+                                            value = """
+                                                {
+                                                  "success": true,
+                                                  "message": "커스텀 질문 답변 생성 성공",
+                                                  "data": {
+                                                    "answer": "자소서 기반 모범 답변",
+                                                    "tip": "답변할 때 유의할 점과 팁"
+                                                  }
+                                                }
+                                                """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청",
+                            content = @Content(
+                                    schema = @Schema(implementation = Map.class),
+                                    examples = @ExampleObject(
+                                            name = "유효성 검증 실패",
+                                            value = """
+                                                {
+                                                  "timestamp": "2025-09-05T14:30:00",
+                                                  "status": 400,
+                                                  "error": "Bad Request",
+                                                  "errorCode": "VALIDATION_ERROR",
+                                                  "message": "질문은 필수입니다.",
+                                                  "errors": {}
+                                                }
+                                                """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 내부 오류",
+                            content = @Content(
+                                    schema = @Schema(implementation = Map.class),
+                                    examples = @ExampleObject(
+                                            name = "답변 생성 실패",
+                                            value = """
+                                                {
+                                                  "timestamp": "2025-09-05T14:30:00",
+                                                  "status": 500,
+                                                  "error": "Internal Server Error",
+                                                  "errorCode": "INTERVIEW_SERVICE_ERROR",
+                                                  "message": "커스텀 질문 답변 생성에 실패했습니다.",
+                                                  "errors": {}
+                                                }
+                                                """
+                                    )
+                            )
+                    )
+            }
+    )
+    @PostMapping("/custom-answer")
+    public ResponseEntity<CommonResponse<CustomAnswerResponse>> createCustomAnswer(
+            @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
+            @Valid @RequestBody CustomQuestionRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String userEmail = userDetails.getUsername();
+        CustomAnswerResponse response = interviewService.createCustomAnswer(
+                coverLetterId, userEmail, request.question());
+
+        return ResponseEntity.ok(CommonResponse.success("커스텀 질문 답변 생성 성공", response));
+    }
+
 
 }

--- a/CVMento/src/main/java/com/cvmento/domain/interview/dto/request/CustomQuestionRequest.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/dto/request/CustomQuestionRequest.java
@@ -1,0 +1,11 @@
+package com.cvmento.domain.interview.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CustomQuestionRequest(
+        @NotBlank(message = "질문은 필수입니다.")
+        @Size(max = 500, message = "질문은 최대 500자까지 가능합니다.")
+        String question
+) {
+}

--- a/CVMento/src/main/java/com/cvmento/domain/interview/dto/response/CustomAnswerResponse.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/dto/response/CustomAnswerResponse.java
@@ -1,0 +1,7 @@
+package com.cvmento.domain.interview.dto.response;
+
+public record CustomAnswerResponse(
+        String answer,
+        String tip
+) {
+}

--- a/CVMento/src/main/java/com/cvmento/domain/interview/entity/CoverLetterQna.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/entity/CoverLetterQna.java
@@ -35,10 +35,10 @@ public class CoverLetterQna extends BaseTimeEntity {
 
     protected CoverLetterQna() {}
 
-    public CoverLetterQna(String question, CoverLetter coverLetter) {
+    public CoverLetterQna(String question, CoverLetter coverLetter, QuestionSourceType sourceType) {
         this.question = question;
         this.coverLetter = coverLetter;
-        this.sourceType = QuestionSourceType.GENERATED; // 기본값으로 GENERATED 설정
+        this.sourceType = sourceType;
     }
 
     public void updateAnswer(String answer) {
@@ -51,5 +51,9 @@ public class CoverLetterQna extends BaseTimeEntity {
     public void updateAnswerAndTip(String answer, String tip) {
         this.answer = answer;
         this.tip = tip;
+    }
+
+    public void updateSourceType(QuestionSourceType sourceType) {
+        this.sourceType = sourceType;
     }
 }

--- a/CVMento/src/main/java/com/cvmento/domain/interview/service/InterviewLlmClientService.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/service/InterviewLlmClientService.java
@@ -2,6 +2,7 @@ package com.cvmento.domain.interview.service;
 
 import com.cvmento.domain.coverLetter.dto.request.LlmRequest;
 import com.cvmento.domain.interview.client.InterviewLlmFeignClient;
+import com.cvmento.domain.interview.dto.response.CustomAnswerResponse;
 import com.cvmento.domain.interview.dto.response.InterviewLlmResponse;
 import com.cvmento.domain.interview.dto.response.InterviewQnaDto;
 import com.cvmento.global.common.util.OpenAiResponseParser;
@@ -49,7 +50,6 @@ public class InterviewLlmClientService {
     private InterviewLlmResponse callLlmApi(LlmRequest request) {
         try {
             log.info("=== Interview LLM API 요청 시작 ===");
-            log.info("요청 모델: {}", request.model());
             log.info("요청 프롬프트 길이: {}", request.input().length());
 
             String rawResponse = getRawResponse(request);
@@ -102,13 +102,9 @@ public class InterviewLlmClientService {
                     .replaceAll("\\s*```", "")
                     .trim();
 
-            log.info("정제된 텍스트: {}", cleanText);
-
             // text가 JSON 형식인지 확인하고 파싱
             if (cleanText.startsWith("{")) {
                 var contentJson = objectMapper.readTree(cleanText);
-
-                log.info("JSON 파싱 성공, 최상위 필드들: {}", contentJson.fieldNames());
 
                 // qnaList 배열 추출
                 if (contentJson.has("qnaList")) {
@@ -145,6 +141,89 @@ public class InterviewLlmClientService {
         } catch (Exception e) {
             log.error("실제 content 파싱 실패: {}", e.getMessage());
             throw new InterviewException("LLM 컨텐츠 파싱에 실패했습니다.", e);
+        }
+    }
+
+    // ======================== 커스텀 프롬프트 메서드 ========================
+    public CustomAnswerResponse generateCustomAnswer(String prompt) {
+        validatePrompt(prompt);
+
+        LlmRequest request = createLlmRequest(prompt);
+        return callCustomAnswerLlmApi(request);
+    }
+
+    private CustomAnswerResponse callCustomAnswerLlmApi(LlmRequest request) {
+        try {
+            log.info("=== Custom Answer LLM API 요청 시작 ===");
+            log.info("요청 모델: {}", request.model());
+            log.info("요청 프롬프트 길이: {}", request.input().length());
+
+            String rawResponse = getRawResponse(request);
+            log.info("=== 원본 응답 받음 ===");
+
+            CustomAnswerResponse response = parseCustomAnswerResponse(rawResponse);
+
+            log.info("=== 변환된 응답 ===");
+            log.info("답변 길이: {}", response.answer() != null ? response.answer().length() : 0);
+
+            return response;
+
+        } catch (Exception e) {
+            log.error("Custom Answer LLM API 호출 실패", e);
+            throw new InterviewException("커스텀 질문 답변 생성에 실패했습니다.", e);
+        }
+    }
+
+    private CustomAnswerResponse parseCustomAnswerResponse(String rawResponse) {
+        try {
+            String textContent = openAiResponseParser.extractTextContent(rawResponse);
+            return parseCustomAnswerContent(textContent);
+
+        } catch (Exception e) {
+            log.error("Custom Answer OpenAI 응답 파싱 실패: {}", e.getMessage());
+            throw new InterviewException("커스텀 답변 파싱에 실패했습니다.", e);
+        }
+    }
+
+    private CustomAnswerResponse parseCustomAnswerContent(String text) {
+        try {
+            log.info("=== Custom Answer 실제 응답 내용 ===");
+            log.info("응답 길이: {} chars", text.length());
+            log.info("응답 내용: {}", text);
+            log.info("============================");
+
+            // 마크다운 코드 블록 제거
+            String cleanText = text.trim()
+                    .replaceAll("```json\\s*", "")
+                    .replaceAll("\\s*```", "")
+                    .trim();
+
+            // JSON 파싱
+            if (cleanText.startsWith("{")) {
+                var contentJson = objectMapper.readTree(cleanText);
+
+                if (contentJson.has("answer") && contentJson.has("tip")) {
+                    String answer = contentJson.get("answer").asText();
+                    String tip = contentJson.get("tip").asText();
+
+                    log.info("커스텀 답변 파싱 성공 - 답변 길이: {}, 팁 길이: {}",
+                            answer.length(), tip.length());
+                    return new CustomAnswerResponse(answer, tip);
+                } else {
+                    log.error("answer 또는 tip 필드가 없습니다. 사용 가능한 필드들:");
+                    contentJson.fieldNames().forEachRemaining(fieldName ->
+                            log.error("- {}: {}", fieldName, contentJson.get(fieldName).getNodeType()));
+                }
+            }
+
+            log.error("커스텀 답변 JSON 파싱 실패 - answer, tip을 찾을 수 없습니다");
+            throw new InterviewException("커스텀 답변 데이터 파싱에 실패했습니다.");
+
+        } catch (InterviewException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("커스텀 답변 content 파싱 실패: {}", e.getMessage());
+            throw new InterviewException("커스텀 답변 컨텐츠 파싱에 실패했습니다.", e);
         }
     }
 }

--- a/CVMento/src/main/java/com/cvmento/domain/interview/service/InterviewLlmPromptService.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/service/InterviewLlmPromptService.java
@@ -28,7 +28,7 @@ public class InterviewLlmPromptService {
     }
 
     public String buildCustomAnswerPrompt(CoverLetter coverLetter, String customQuestion) {
-        return buildPromptStructure() +
+        return buildCustomAnswerPromptStructure() +
                 buildCoverLetterSection(coverLetter) +
                 buildCustomQuestionSection(customQuestion) +
                 buildCustomAnswerRequestSection() +
@@ -43,6 +43,14 @@ public class InterviewLlmPromptService {
             제공된 자소서를 분석하여 실제 면접에서 나올 수 있는 예상 질문과 모범 답변을 생성해주세요.
             
             """;
+    }
+
+    private String buildCustomAnswerPromptStructure() {
+        return """
+        당신은 면접을 준비하는 구직자입니다.
+        제공된 자소서를 바탕으로 면접관의 질문에 대해 효과적이고 설득력 있는 답변을 준비해주세요.
+        
+        """;
     }
 
     private String buildCoverLetterSection(CoverLetter coverLetter) {
@@ -67,10 +75,10 @@ public class InterviewLlmPromptService {
 
     private String buildCustomQuestionSection(String customQuestion) {
         return """
-            ## 면접 질문
-            다음 질문에 대해 위 자소서를 기반으로 한 모범 답변을 생성해주세요:
-            
-            **질문**: """ + customQuestion + "\n\n";
+        ## 면접관의 질문
+        다음 질문에 대해 위 자소서를 기반으로 한 모범 답변을 준비해주세요:
+        
+        **질문**: """ + customQuestion + "\n\n";
     }
 
     // ======================== Request Sections ========================
@@ -98,10 +106,10 @@ public class InterviewLlmPromptService {
 
     private String buildCustomAnswerRequestSection() {
         return """
-            ## 작업 요청
-            위 질문에 대해 자소서 내용을 기반으로 한 모범 답변과 면접 팁을 생성해주세요.
-            
-            """ + buildSingleAnswerJsonFormat();
+        ## 답변 작성 요청
+        위 면접관의 질문에 대해 자소서 내용을 기반으로 한 효과적인 답변과 답변 시 주의사항을 작성해주세요.
+        
+        """ + buildSingleAnswerJsonFormat();
     }
 
     // ======================== JSON Format Sections ========================
@@ -174,15 +182,19 @@ public class InterviewLlmPromptService {
            - 실제 면접에서 말하는 것처럼 자연스럽게 작성
            - "정의:", "이유:", "예시:" 등의 구조 라벨 절대 사용 금지
            - 한 문단으로 자연스럽게 연결되는 서술형 답변
-        3. **논리적 흐름**: 
-           - 핵심 메시지 → 근거/이유 → 구체적 경험 → 결론/다짐 순으로 자연스럽게 연결
+        3. **질문 유형별 답변 패턴**: 
+           - 기술 질문: 기술 설명 위주, 자소서 연결 금지 (미래 계획/포부 금지)
+           - 경험 질문: 구체적 상황 + 행동 + 결과
+           - 가치관 질문: 개인 가치관 + 자소서 경험 연결
+        4. **논리적 흐름**: 
+           - 핵심 메시지 → 근거/설명 → 구체적 경험 순으로 자연스럽게 연결
            - 문장 간 자연스러운 연결어 사용 ("그래서", "때문에", "또한" 등)
-        4. **표현 방식**: 
+        5. **표현 방식**: 
            - "구체적으로", "체계적으로" 등 수식어 남용 금지
            - "~하겠습니다" 반복 사용 지양, 다양한 마무리 표현 활용
            - 모호한 표현 대신 구체적 사례와 기술명 활용
-        5. **현실적 수준**: 신입 개발자 수준에 맞는 경험과 성과만 언급
-        6. **톤**: 겸손하되 자신감 있게, 학습 의지와 성장 잠재력 강조
+        6. **현실적 수준**: 신입 개발자 수준에 맞는 경험과 성과만 언급
+        7. **톤**: 겸손하되 자신감 있게, 과도한 포부나 다짐 지양
         
         """;
     }
@@ -193,7 +205,13 @@ public class InterviewLlmPromptService {
         1. **실용성**: 면접 현장에서 즉시 적용 가능한 구체적 조언
         2. **길이**: 60~100자의 간결한 한 문장
         3. **톤**: 친근한 조언 형태, 지시문 느낌 배제
-        4. **내용**: 답변 시 강조할 포인트나 주의사항 위주
+        4. **내용 구성**:\s
+           - 답변 시 강조할 포인트나 주의사항
+           - 자소서와의 자연스러운 연결 방법 제시 (해당되는 경우에만)
+           - 면접관이 추가로 궁금해할 수 있는 부분 예상
+        5. **자소서 연결 가이드**:\s
+           - 기술 질문의 경우, 자소서의 관련 프로젝트나 경험과 연결하는 방법 제시
+           - "○○ 프로젝트 경험과 연결해서 설명하면 더 설득력 있어요" 형태
         
         """;
     }
@@ -221,6 +239,23 @@ public class InterviewLlmPromptService {
         """;
     }
 
+    private String buildAnswerAdditionalCautions() {
+        return """
+        #### 추가 주의사항
+        - 자소서 우선: 질문과 직접 연결되는 자소서 경험/가치관을 최우선으로 사용하라.
+        - 없다 → 유사 경험 연결(가정 명시): 직접 사례가 없을 경우, 가장 인접한 경험으로 추론하되
+          다음과 같은 전환 문구를 사용하여 가정임을 명확히 하라.
+          · "자소서에서 언급한 ○○ 경험을 바탕으로 보면…"
+          · "직접 사례는 없지만, 유사 상황에서는 이렇게 대응했을 것 같다…"
+        - 상식/일반 질문: 자소서와 연결 가능하면 간단히 연결하고, 어려우면 지원자로서의
+          기본 태도/가치관을 간결히 제시한 뒤 자소서 키워드를 가볍게 보강하라.
+          · "자소서에 직접 언급하진 않았지만, 내가 중요하게 생각하는 것은 △△이며,
+             □□ 경험에서도 이 점을 중시했다."
+        - 금지/주의: 자소서와 모순되는 사실 생성 금지, 과도한 추측 및 개인정보 생성 금지.
+          불확실성은 전환 문구를 사용해 범위를 한정하라.
+        """;
+    }
+
     // ======================== Complete Guidelines ========================
 
     private String buildCompleteGuidelines() {
@@ -244,6 +279,7 @@ public class InterviewLlmPromptService {
         return "### 중요 지침\n" +
                 buildAnswerGenerationGuidelines() +
                 buildTipGenerationGuidelines() +
-                buildCommonRequirements();
+                buildCommonRequirements()+
+                buildAnswerAdditionalCautions();
     }
 }

--- a/CVMento/src/main/java/com/cvmento/domain/interview/service/InterviewService.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/service/InterviewService.java
@@ -2,10 +2,7 @@ package com.cvmento.domain.interview.service;
 
 import com.cvmento.domain.coverLetter.entity.CoverLetter;
 import com.cvmento.domain.coverLetter.repository.CoverLetterRepository;
-import com.cvmento.domain.interview.dto.response.InterviewLlmResponse;
-import com.cvmento.domain.interview.dto.response.InterviewQnaDto;
-import com.cvmento.domain.interview.dto.response.InterviewQnaListResponse;
-import com.cvmento.domain.interview.dto.response.InterviewQnaResponse;
+import com.cvmento.domain.interview.dto.response.*;
 import com.cvmento.domain.interview.entity.CoverLetterQna;
 import com.cvmento.domain.interview.enums.QuestionSourceType;
 import com.cvmento.domain.interview.repository.CoverLetterQnaRepository;
@@ -62,6 +59,34 @@ public class InterviewService {
         return generateQuestionsWithPrompt(coverLetter, prompt, existingCount == 0 ? "초기" : "추가");
     }
 
+    /**
+     * 사용자 커스텀 질문에 대한 AI 답변 생성 및 저장
+     */
+    @Transactional
+    public CustomAnswerResponse createCustomAnswer(Long coverLetterId, String userEmail, String customQuestion) {
+        CoverLetter coverLetter = findCoverLetterByIdAndUser(coverLetterId, userEmail);
+
+        // 프롬프트 생성
+        String prompt = promptService.buildCustomAnswerPrompt(coverLetter, customQuestion);
+
+        try {
+            // LLM API 호출
+            CustomAnswerResponse response = llmClientService.generateCustomAnswer(prompt);
+
+            // DB에 저장
+            saveCustomQuestionAndAnswer(customQuestion, response, coverLetter);
+
+            log.info("커스텀 질문 답변 생성 완료 - 자소서 ID: {}, 질문: {}",
+                    coverLetter.getCoverLetterId(), customQuestion);
+
+            return response;
+
+        } catch (Exception e) {
+            log.error("커스텀 질문 답변 생성 실패 - 자소서 ID: {}", coverLetter.getCoverLetterId(), e);
+            throw new InterviewException("커스텀 질문 답변 생성에 실패했습니다.", e);
+        }
+    }
+
     // ======================== 유틸리티 메서드 ========================
 
     private String buildPromptByCount(CoverLetter coverLetter, long existingCount) {
@@ -94,7 +119,7 @@ public class InterviewService {
         List<CoverLetterQna> savedQnas = new ArrayList<>();
 
         for (InterviewQnaDto qnaData : qnaDataList) {
-            CoverLetterQna qna = new CoverLetterQna(qnaData.question(), coverLetter);
+            CoverLetterQna qna = new CoverLetterQna(qnaData.question(), coverLetter, QuestionSourceType.GENERATED);
             qna.updateAnswerAndTip(qnaData.answer(), qnaData.tip());
             CoverLetterQna savedQna = coverLetterQnaRepository.save(qna);
             savedQnas.add(savedQna);
@@ -124,10 +149,13 @@ public class InterviewService {
     }
 
     private CoverLetter findCoverLetterByIdAndUser(Long coverLetterId, String userEmail) {
-        Member member = memberRepository.findByEmail(userEmail)
-                .orElseThrow(() -> new MemberNotFoundException("사용자를 찾을 수 없습니다."));
-
-        return coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, member)
+        return coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail)
                 .orElseThrow(() -> new CoverLetterException("자소서를 찾을 수 없습니다."));
+    }
+
+    private void saveCustomQuestionAndAnswer(String question, CustomAnswerResponse response, CoverLetter coverLetter) {
+        CoverLetterQna qna = new CoverLetterQna(question, coverLetter, QuestionSourceType.CUSTOM);
+        qna.updateAnswerAndTip(response.answer(), response.tip());
+        coverLetterQnaRepository.save(qna);
     }
 }

--- a/CVMento/src/main/java/com/cvmento/global/exception/customException/InterviewLimitExceededException.java
+++ b/CVMento/src/main/java/com/cvmento/global/exception/customException/InterviewLimitExceededException.java
@@ -1,6 +1,6 @@
 package com.cvmento.global.exception.customException;
 
-public class InterviewLimitExceededException extends InterviewException {
+public class InterviewLimitExceededException extends RuntimeException {
     public InterviewLimitExceededException(String message) {
         super(message);
     }

--- a/CVMento/src/test/java/com/cvmento/domain/interview/controller/InterviewControllerTest.java
+++ b/CVMento/src/test/java/com/cvmento/domain/interview/controller/InterviewControllerTest.java
@@ -1,5 +1,7 @@
 package com.cvmento.domain.interview.controller;
 
+import com.cvmento.domain.interview.dto.request.CustomQuestionRequest;
+import com.cvmento.domain.interview.dto.response.CustomAnswerResponse;
 import com.cvmento.domain.interview.dto.response.InterviewQnaListResponse;
 import com.cvmento.domain.interview.dto.response.InterviewQnaResponse;
 import com.cvmento.domain.interview.service.InterviewService;
@@ -359,6 +361,121 @@ class InterviewControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("createCustomAnswer 메서드")
+    class CreateCustomAnswerTest {
+
+        @Test
+        @DisplayName("정상적인 커스텀 답변 생성")
+        void shouldCreateCustomAnswerSuccessfully() {
+            log.info("=== 테스트 시작: 정상적인 커스텀 답변 생성 ===");
+
+            // given
+            CustomQuestionRequest request = createMockCustomQuestionRequest();
+            CustomAnswerResponse mockResponse = createMockCustomAnswerResponse();
+            log.info("Mock 요청 생성: question='{}'", request.question());
+            log.info("Mock 응답 생성: answer='{}', tip='{}'", mockResponse.answer(), mockResponse.tip());
+
+            given(interviewService.createCustomAnswer(coverLetterId, userEmail, request.question()))
+                    .willReturn(mockResponse);
+            log.info("Mock 설정: interviewService.createCustomAnswer({}, {}, '{}') -> mockResponse 반환",
+                    coverLetterId, userEmail, request.question());
+
+            // when
+            log.info("=== 컨트롤러 메서드 실행 ===");
+            ResponseEntity<CommonResponse<CustomAnswerResponse>> result =
+                    interviewController.createCustomAnswer(coverLetterId, request, mockUserDetails);
+            log.info("컨트롤러 응답: statusCode={}, hasBody={}",
+                    result.getStatusCode(), result.getBody() != null);
+
+            // then
+            log.info("=== 결과 검증 ===");
+            assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            assertThat(result.getBody()).isNotNull();
+            log.info("✅ 응답 바디 null 아님 검증 통과");
+
+            assertThat(result.getBody().isSuccess()).isTrue();
+            log.info("✅ success 필드 검증 통과: {}", result.getBody().isSuccess());
+
+            assertThat(result.getBody().getMessage()).isEqualTo("커스텀 질문 답변 생성 성공");
+            log.info("✅ 메시지 검증 통과: '{}'", result.getBody().getMessage());
+
+            assertThat(result.getBody().getData().answer()).isEqualTo(mockResponse.answer());
+            log.info("✅ answer 필드 검증 통과: '{}'", result.getBody().getData().answer());
+
+            assertThat(result.getBody().getData().tip()).isEqualTo(mockResponse.tip());
+            log.info("✅ tip 필드 검증 통과: '{}'", result.getBody().getData().tip());
+
+            verify(interviewService).createCustomAnswer(coverLetterId, userEmail, request.question());
+            log.info("✅ 서비스 메서드 호출 검증 통과");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자일 때 예외 발생")
+        void shouldThrowExceptionWhenMemberNotFound() {
+            log.info("=== 테스트 시작: 존재하지 않는 사용자일 때 예외 발생 ===");
+
+            // given
+            CustomQuestionRequest request = createMockCustomQuestionRequest();
+            given(interviewService.createCustomAnswer(coverLetterId, userEmail, request.question()))
+                    .willThrow(new MemberNotFoundException("사용자를 찾을 수 없습니다."));
+            log.info("Mock 설정: MemberNotFoundException 발생하도록 설정");
+
+            // when & then
+            log.info("예외 발생 예상 - MemberNotFoundException");
+            assertThatThrownBy(() ->
+                    interviewController.createCustomAnswer(coverLetterId, request, mockUserDetails))
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessage("사용자를 찾을 수 없습니다.");
+            log.info("✅ 예상된 예외 발생 확인");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 자소서일 때 예외 발생")
+        void shouldThrowExceptionWhenCoverLetterNotFound() {
+            log.info("=== 테스트 시작: 존재하지 않는 자소서일 때 예외 발생 ===");
+
+            // given
+            CustomQuestionRequest request = createMockCustomQuestionRequest();
+            given(interviewService.createCustomAnswer(coverLetterId, userEmail, request.question()))
+                    .willThrow(new CoverLetterException("자소서를 찾을 수 없습니다."));
+            log.info("Mock 설정: CoverLetterException 발생하도록 설정");
+
+            // when & then
+            log.info("예외 발생 예상 - CoverLetterException");
+            assertThatThrownBy(() ->
+                    interviewController.createCustomAnswer(coverLetterId, request, mockUserDetails))
+                    .isInstanceOf(CoverLetterException.class)
+                    .hasMessage("자소서를 찾을 수 없습니다.");
+            log.info("✅ 예상된 예외 발생 확인");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("LLM 서비스 오류시 예외 발생")
+        void shouldThrowExceptionWhenServiceError() {
+            log.info("=== 테스트 시작: LLM 서비스 오류시 예외 발생 ===");
+
+            // given
+            CustomQuestionRequest request = createMockCustomQuestionRequest();
+            given(interviewService.createCustomAnswer(coverLetterId, userEmail, request.question()))
+                    .willThrow(new InterviewException("커스텀 질문 답변 생성에 실패했습니다."));
+            log.info("Mock 설정: InterviewException 발생하도록 설정");
+
+            // when & then
+            log.info("예외 발생 예상 - InterviewException");
+            assertThatThrownBy(() ->
+                    interviewController.createCustomAnswer(coverLetterId, request, mockUserDetails))
+                    .isInstanceOf(InterviewException.class)
+                    .hasMessage("커스텀 질문 답변 생성에 실패했습니다.");
+            log.info("✅ 예상된 서비스 예외 발생 확인");
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
     // ================ 테스트 헬퍼 메서드들 ================
 
     private List<InterviewQnaResponse> createMockQnaResponseList(int count) {
@@ -382,5 +499,18 @@ class InterviewControllerTest {
 
         log.debug("가짜 질문 응답 목록 생성 완료: 총 {}개", qnaList.size());
         return qnaList;
+    }
+
+    private CustomQuestionRequest createMockCustomQuestionRequest() {
+        log.debug("가짜 커스텀 질문 요청 생성");
+        return new CustomQuestionRequest("면접에서 가장 중요하게 생각하는 가치는 무엇인가요?");
+    }
+
+    private CustomAnswerResponse createMockCustomAnswerResponse() {
+        log.debug("가짜 커스텀 답변 응답 생성");
+        return new CustomAnswerResponse(
+                "저는 팀워크와 지속적인 학습을 가장 중요하게 생각합니다. 자소서에서 언급한 팀 프로젝트 경험을 통해...",
+                "구체적인 경험 사례와 함께 개인의 가치관을 명확히 표현하세요."
+        );
     }
 }

--- a/CVMento/src/test/java/com/cvmento/domain/interview/service/InterviewServiceTest.java
+++ b/CVMento/src/test/java/com/cvmento/domain/interview/service/InterviewServiceTest.java
@@ -2,6 +2,7 @@ package com.cvmento.domain.interview.service;
 
 import com.cvmento.domain.coverLetter.entity.CoverLetter;
 import com.cvmento.domain.coverLetter.repository.CoverLetterRepository;
+import com.cvmento.domain.interview.dto.response.CustomAnswerResponse;
 import com.cvmento.domain.interview.dto.response.InterviewLlmResponse;
 import com.cvmento.domain.interview.dto.response.InterviewQnaDto;
 import com.cvmento.domain.interview.dto.response.InterviewQnaListResponse;
@@ -10,6 +11,7 @@ import com.cvmento.domain.interview.enums.QuestionSourceType;
 import com.cvmento.domain.interview.repository.CoverLetterQnaRepository;
 import com.cvmento.domain.member.entity.Member;
 import com.cvmento.domain.member.repository.MemberRepository;
+import com.cvmento.global.exception.customException.CoverLetterException;
 import com.cvmento.global.exception.customException.InterviewException;
 import com.cvmento.global.exception.customException.InterviewLimitExceededException;
 import com.cvmento.global.exception.customException.MemberNotFoundException;
@@ -369,13 +371,161 @@ class InterviewServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("createCustomAnswer 메서드")
+    class CreateCustomAnswerTest {
+
+        @BeforeEach
+        void setUp() {
+            log.info("--- CreateCustomAnswerTest 공통 Mock 설정 ---");
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
+                    .willReturn(Optional.of(testCoverLetter));
+            log.info("CoverLetter 조회 Mock 설정 완료\n");
+        }
+
+        @Test
+        @DisplayName("커스텀 질문 답변 생성 및 저장 성공")
+        void shouldCreateCustomAnswerSuccessfully() {
+            log.info("=== 테스트 시작: 커스텀 질문 답변 생성 및 저장 성공 ===");
+
+            // given
+            String customQuestion = "면접에서 가장 중요하게 생각하는 가치는 무엇인가요?";
+            log.info("커스텀 질문: '{}'", customQuestion);
+
+            String mockPrompt = "커스텀 답변 프롬프트";
+            given(promptService.buildCustomAnswerPrompt(testCoverLetter, customQuestion))
+                    .willReturn(mockPrompt);
+            log.info("Mock 설정: 생성된 프롬프트 = '{}'", mockPrompt);
+
+            CustomAnswerResponse mockResponse = createMockCustomAnswerResponse();
+            given(llmClientService.generateCustomAnswer(mockPrompt))
+                    .willReturn(mockResponse);
+            log.info("Mock 설정: LLM 응답 answer='{}', tip='{}'",
+                    mockResponse.answer(), mockResponse.tip());
+
+            // ArgumentCaptor를 사용하여 저장되는 객체 캡처
+            ArgumentCaptor<CoverLetterQna> qnaCaptor = ArgumentCaptor.forClass(CoverLetterQna.class);
+            given(coverLetterQnaRepository.save(qnaCaptor.capture()))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            log.info("=== 메서드 실행 ===");
+            CustomAnswerResponse result = interviewService.createCustomAnswer(coverLetterId, userEmail, customQuestion);
+
+            // then
+            log.info("=== 결과 검증 ===");
+            log.info("반환된 응답: answer='{}', tip='{}'", result.answer(), result.tip());
+
+            assertThat(result.answer()).isEqualTo(mockResponse.answer());
+            log.info("✅ answer 필드 검증 통과: '{}'", result.answer());
+
+            assertThat(result.tip()).isEqualTo(mockResponse.tip());
+            log.info("✅ tip 필드 검증 통과: '{}'", result.tip());
+
+            // 저장된 객체 상세 검증
+            CoverLetterQna savedQna = qnaCaptor.getValue();
+            log.info("실제로 저장된 질문: question='{}', answer='{}', tip='{}', sourceType='{}'",
+                    savedQna.getQuestion(), savedQna.getAnswer(), savedQna.getTip(), savedQna.getSourceType());
+
+            assertThat(savedQna.getQuestion()).isEqualTo(customQuestion);
+            log.info("✅ 저장된 질문 검증 통과");
+
+            assertThat(savedQna.getAnswer()).isEqualTo(mockResponse.answer());
+            log.info("✅ 저장된 답변 검증 통과");
+
+            assertThat(savedQna.getTip()).isEqualTo(mockResponse.tip());
+            log.info("✅ 저장된 팁 검증 통과");
+
+            assertThat(savedQna.getSourceType()).isEqualTo(QuestionSourceType.CUSTOM);
+            log.info("✅ sourceType이 CUSTOM으로 저장됨 검증 통과");
+
+            // 메서드 호출 검증
+            log.info("=== 메서드 호출 검증 ===");
+            verify(promptService).buildCustomAnswerPrompt(testCoverLetter, customQuestion);
+            log.info("✅ promptService.buildCustomAnswerPrompt() 호출 확인");
+
+            verify(llmClientService).generateCustomAnswer(mockPrompt);
+            log.info("✅ llmClientService.generateCustomAnswer('{}') 호출 확인", mockPrompt);
+
+            verify(coverLetterQnaRepository).save(any(CoverLetterQna.class));
+            log.info("✅ coverLetterQnaRepository.save() 호출 확인");
+
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("LLM이 JSON이 아닌 응답을 보낼 때")
+        void shouldThrowExceptionWhenLlmReturnsInvalidJson() {
+            log.info("=== 테스트 시작: LLM이 JSON이 아닌 응답을 보낼 때 ===");
+
+            // given
+            String customQuestion = "테스트 질문";
+            String mockPrompt = "프롬프트";
+
+            given(promptService.buildCustomAnswerPrompt(testCoverLetter, customQuestion))
+                    .willReturn(mockPrompt);
+            log.info("Mock 설정: 프롬프트 생성");
+
+            // LLM이 일반 텍스트 응답을 보내는 상황
+            given(llmClientService.generateCustomAnswer(mockPrompt))
+                    .willThrow(new InterviewException("커스텀 답변 데이터 파싱에 실패했습니다."));
+            log.info("Mock 설정: LLM이 파싱 불가능한 응답 반환");
+
+            // when & then
+            log.info("예외 발생 예상 - InterviewException");
+            assertThatThrownBy(() ->
+                    interviewService.createCustomAnswer(coverLetterId, userEmail, customQuestion))
+                    .isInstanceOf(InterviewException.class)
+                    .hasMessage("커스텀 질문 답변 생성에 실패했습니다.");
+            log.info("✅ 예상된 JSON 파싱 예외 발생 확인");
+
+            verify(coverLetterQnaRepository, never()).save(any());
+            log.info("✅ 저장 메서드가 호출되지 않음을 확인 (파싱 실패로 인해)");
+
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("LLM 응답에 answer 필드가 없을 때")
+        void shouldThrowExceptionWhenAnswerFieldMissing() {
+            log.info("=== 테스트 시작: LLM 응답에 answer 필드가 없을 때 ===");
+
+            // given
+            String customQuestion = "테스트 질문";
+            String mockPrompt = "프롬프트";
+
+            given(promptService.buildCustomAnswerPrompt(testCoverLetter, customQuestion))
+                    .willReturn(mockPrompt);
+            log.info("Mock 설정: 프롬프트 생성");
+
+            // LLM이 answer 필드가 누락된 응답을 보내는 상황
+            given(llmClientService.generateCustomAnswer(mockPrompt))
+                    .willThrow(new InterviewException("커스텀 답변 데이터 파싱에 실패했습니다."));
+            log.info("Mock 설정: LLM이 answer 필드 누락된 응답 반환");
+
+            // when & then
+            log.info("예외 발생 예상 - InterviewException");
+            assertThatThrownBy(() ->
+                    interviewService.createCustomAnswer(coverLetterId, userEmail, customQuestion))
+                    .isInstanceOf(InterviewException.class)
+                    .hasMessage("커스텀 질문 답변 생성에 실패했습니다.");
+            log.info("✅ 예상된 필드 누락 예외 발생 확인");
+
+            verify(coverLetterQnaRepository, never()).save(any());
+            log.info("✅ 저장 메서드가 호출되지 않음을 확인 (필드 누락으로 인해)");
+
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+    }
+
     // ================ 테스트 헬퍼 메서드들 ================
 
     private List<CoverLetterQna> createMockQnaList(int count) {
         log.debug("가짜 질문 목록 생성 시작: {}개", count);
         List<CoverLetterQna> qnaList = new ArrayList<>();
         for (int i = 1; i <= count; i++) {
-            CoverLetterQna qna = new CoverLetterQna("질문 " + i, testCoverLetter);
+            CoverLetterQna qna = new CoverLetterQna("질문 " + i, testCoverLetter, QuestionSourceType.GENERATED);
             qna.updateAnswerAndTip("답변 " + i, "팁 " + i);
             qnaList.add(qna);
             log.debug("가짜 질문 {}번 생성: question='질문 {}', answer='답변 {}', tip='팁 {}'", i, i, i, i);
@@ -406,5 +556,13 @@ class InterviewServiceTest {
         field.setAccessible(true);
         field.set(target, value);
         log.debug("리플렉션으로 필드 설정: {}.{} = {}", target.getClass().getSimpleName(), fieldName, value);
+    }
+
+    private CustomAnswerResponse createMockCustomAnswerResponse() {
+        log.debug("가짜 커스텀 답변 응답 생성");
+        return new CustomAnswerResponse(
+                "저는 팀워크와 지속적인 학습을 가장 중요하게 생각합니다. 자소서에서 언급한 팀 프로젝트 경험을 통해...",
+                "구체적인 경험 사례와 함께 개인의 가치관을 명확히 표현하세요."
+        );
     }
 }


### PR DESCRIPTION
+ 추가적으로 FT님께서 피드백 주신 인터뷰 서비스 내의 예외처리 부분 단축 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 사용자 지정 질문에 대한 AI 답변 생성 엔드포인트 추가. 요청 값 검증(최대 500자) 및 자소서 소유자 확인, 답변(answer)과 팁(tip) 반환.
- 리팩터
  - 면접 질문 생성 시 사용자 이메일 기반 조회로 정합성 개선 및 생성 수 제한 적용(초과 시 오류).
  - QnA 출처 타입 관리로 기록 정확도 향상, 프롬프트 가이드라인 고도화로 응답 품질 개선.
- 테스트
  - 컨트롤러/서비스 단위 테스트 추가(정상/오류 흐름 검증).
- 기타
  - IDE 모듈 및 컴파일러 설정 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->