### PR TITLE
Feature/user quota limit : 유저 사용 제한 관련

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -19,6 +19,13 @@
         </processorPath>
         <module name="cvmento.main" />
       </profile>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
+        </processorPath>
+        <module name="cvmento.test" />
+      </profile>
     </annotationProcessing>
   </component>
   <component name="JavacSettings">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/AIBE2_FinalProject_CodeHansabari_BE.iml" filepath="$PROJECT_DIR$/.idea/AIBE2_FinalProject_CodeHansabari_BE.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/cvmento.main.iml" filepath="$PROJECT_DIR$/.idea/modules/cvmento.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/cvmento.test.iml" filepath="$PROJECT_DIR$/.idea/modules/cvmento.test.iml" />
     </modules>
   </component>
 </project>

--- a/CVMento/src/main/java/com/cvmento/CvMentoApplication.java
+++ b/CVMento/src/main/java/com/cvmento/CvMentoApplication.java
@@ -1,12 +1,22 @@
 package com.cvmento;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 public class CvMentoApplication {
+
+	@PostConstruct
+	public void init() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(CvMentoApplication.class, args);

--- a/CVMento/src/main/java/com/cvmento/domain/auth/service/GoogleOAuthService.java
+++ b/CVMento/src/main/java/com/cvmento/domain/auth/service/GoogleOAuthService.java
@@ -13,6 +13,7 @@ import com.cvmento.global.exception.customException.GoogleApiException;
 import com.cvmento.global.exception.customException.InvalidAuthorizationCodeException;
 import com.cvmento.global.exception.customException.InvalidTokenException;
 import com.cvmento.global.security.TokenService;
+import com.cvmento.global.usage.service.NewUserTokenInitializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
@@ -45,6 +46,7 @@ public class GoogleOAuthService {
     private final CookieUtil cookieUtil;
     private final RestTemplate restTemplate = new RestTemplate();
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final NewUserTokenInitializer newUserTokenInitializer;
 
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
     private String googleClientId;
@@ -306,7 +308,20 @@ public class GoogleOAuthService {
             Member newMember = new Member(userInfo.getGoogleId(), userInfo.getEmail(),
                     userInfo.getName(), userInfo.getPicture());
             newMember.updateLastLoginAt(LocalDateTime.now());
-            return memberRepository.save(newMember);
+            Member savedMember = memberRepository.save(newMember);
+
+            // 🔥 신규 사용자 토큰 초기화 (추가된 부분)
+            try {
+                newUserTokenInitializer.initializeNewUserTokens(savedMember.getMemberId());
+                log.info("신규 가입 사용자 토큰 초기화 완료 - 사용자 ID: {}, 이메일: {}",
+                        savedMember.getMemberId(), savedMember.getEmail());
+            } catch (Exception e) {
+                log.error("신규 사용자 토큰 초기화 실패 - 사용자 ID: {}, 이메일: {}, 오류: {}",
+                        savedMember.getMemberId(), savedMember.getEmail(), e.getMessage());
+                // 토큰 초기화 실패가 로그인을 방해하지 않도록 예외를 던지지 않음
+            }
+
+            return savedMember;
         }
     }
 

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/controller/CoverLetterAiController.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/controller/CoverLetterAiController.java
@@ -5,6 +5,8 @@ import com.cvmento.domain.coverLetter.dto.response.CoverLetterAiResponse;
 import com.cvmento.domain.coverLetter.service.CoverLetterAiService;
 import com.cvmento.global.common.dto.CommonResponse;
 import com.cvmento.global.exception.customException.CoverLetterAiException;
+import com.cvmento.global.usage.annotation.RequireTokens;
+import com.cvmento.global.usage.enums.UsageType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -104,6 +106,7 @@ public class CoverLetterAiController {
             }
     )
     @PostMapping("/ai-improve")
+    @RequireTokens(UsageType.COVERLETTER_REVIEW)
     public ResponseEntity<CommonResponse<CoverLetterAiResponse>> improveCoverLetter(
             @Valid @RequestBody CoverLetterAiRequest request,
             @AuthenticationPrincipal UserDetails userDetails

--- a/CVMento/src/main/java/com/cvmento/domain/interview/controller/InterviewController.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/controller/InterviewController.java
@@ -86,7 +86,6 @@ public class InterviewController {
             }
     )
     @GetMapping
-    @RequireTokens(UsageType.INTERVIEW_AUTO)
     public ResponseEntity<CommonResponse<InterviewQnaListResponse>> getInterviewQuestions(
             @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
             @AuthenticationPrincipal UserDetails userDetails
@@ -176,7 +175,7 @@ public class InterviewController {
             }
     )
     @PostMapping
-    @RequireTokens(UsageType.INTERVIEW_CUSTOM)
+    @RequireTokens(UsageType.INTERVIEW_AUTO)
     public ResponseEntity<CommonResponse<InterviewQnaListResponse>> createInterviewQuestions(
             @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
             @AuthenticationPrincipal UserDetails userDetails
@@ -257,6 +256,7 @@ public class InterviewController {
             }
     )
     @PostMapping("/custom-answer")
+    @RequireTokens(UsageType.INTERVIEW_CUSTOM)
     public ResponseEntity<CommonResponse<CustomAnswerResponse>> createCustomAnswer(
             @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
             @Valid @RequestBody CustomQuestionRequest request,

--- a/CVMento/src/main/java/com/cvmento/domain/interview/controller/InterviewController.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/controller/InterviewController.java
@@ -3,6 +3,8 @@ package com.cvmento.domain.interview.controller;
 import com.cvmento.domain.interview.dto.response.InterviewQnaListResponse;
 import com.cvmento.domain.interview.service.InterviewService;
 import com.cvmento.global.common.dto.CommonResponse;
+import com.cvmento.global.usage.annotation.RequireTokens;
+import com.cvmento.global.usage.enums.UsageType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -81,6 +83,7 @@ public class InterviewController {
             }
     )
     @GetMapping
+    @RequireTokens(UsageType.INTERVIEW_AUTO)
     public ResponseEntity<CommonResponse<InterviewQnaListResponse>> getInterviewQuestions(
             @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
             @AuthenticationPrincipal UserDetails userDetails
@@ -170,6 +173,7 @@ public class InterviewController {
             }
     )
     @PostMapping
+    @RequireTokens(UsageType.INTERVIEW_CUSTOM)
     public ResponseEntity<CommonResponse<InterviewQnaListResponse>> createInterviewQuestions(
             @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
             @AuthenticationPrincipal UserDetails userDetails

--- a/CVMento/src/main/java/com/cvmento/domain/member/repository/MemberRepository.java
+++ b/CVMento/src/main/java/com/cvmento/domain/member/repository/MemberRepository.java
@@ -1,11 +1,13 @@
 package com.cvmento.domain.member.repository;
 
 import com.cvmento.domain.member.entity.Member;
+import com.cvmento.domain.member.enums.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -24,4 +26,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByGoogleId(String googleId);
+
+    List<Member> findByStatus(UserStatus status);
 }

--- a/CVMento/src/main/java/com/cvmento/global/common/dto/CommonResponse.java
+++ b/CVMento/src/main/java/com/cvmento/global/common/dto/CommonResponse.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-// ApiResponse → CommonResponse로 이름 변경
 @Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/CVMento/src/main/java/com/cvmento/global/exception/GlobalExceptionHandler.java
+++ b/CVMento/src/main/java/com/cvmento/global/exception/GlobalExceptionHandler.java
@@ -169,4 +169,28 @@ public class GlobalExceptionHandler {
         );
     }
 
+    @ExceptionHandler(UsageLimitExceededException.class)
+    public ResponseEntity<Map<String, Object>> handleUsageLimitExceededException(
+            UsageLimitExceededException ex, HttpServletRequest request) {
+
+        log.warn("사용량 제한 초과 - 기능: {}, 필요토큰: {}, 보유토큰: {}",
+                ex.getUsageType().getDescription(), ex.getRequiredTokens(), ex.getRemainingTokens());
+
+        // 추가 정보를 errors 맵에 포함
+        Map<String, String> errors = Map.of(
+                "usageType", ex.getUsageType().name(),
+                "remainingTokens", String.valueOf(ex.getRemainingTokens()),
+                "requiredTokens", String.valueOf(ex.getRequiredTokens()),
+                "nextRefillTime", ex.getNextRefillTime().toString()
+        );
+
+        return buildErrorResponse(
+                request,
+                HttpStatus.TOO_MANY_REQUESTS, // 429 상태코드가 적절
+                "USAGE_LIMIT_EXCEEDED",
+                ex.getMessage(),
+                errors
+        );
+    }
+
 }

--- a/CVMento/src/main/java/com/cvmento/global/exception/customException/UsageLimitExceededException.java
+++ b/CVMento/src/main/java/com/cvmento/global/exception/customException/UsageLimitExceededException.java
@@ -1,0 +1,32 @@
+package com.cvmento.global.exception.customException;
+
+
+import com.cvmento.global.usage.enums.UsageType;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 통합 토큰 사용량 제한 초과 예외
+ */
+@Getter
+public class UsageLimitExceededException extends RuntimeException {
+
+    private final UsageType usageType;
+    private final int remainingTokens;
+    private final int requiredTokens;
+    private final LocalDateTime nextRefillTime;
+
+    public UsageLimitExceededException(UsageType usageType, int remainingTokens, int requiredTokens, LocalDateTime nextRefillTime) {
+        super(buildMessage(usageType, remainingTokens, requiredTokens, nextRefillTime));
+        this.usageType = usageType;
+        this.remainingTokens = remainingTokens;
+        this.requiredTokens = requiredTokens;
+        this.nextRefillTime = nextRefillTime;
+    }
+
+    private static String buildMessage(UsageType usageType, int remainingTokens, int requiredTokens, LocalDateTime nextRefillTime) {
+        return String.format("토큰이 부족합니다. 기능: %s, 필요: %d개, 보유: %d개, 다음 충전: %s",
+                usageType.getDescription(), requiredTokens, remainingTokens, nextRefillTime);
+    }
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/annotation/RequireTokens.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/annotation/RequireTokens.java
@@ -1,0 +1,22 @@
+package com.cvmento.global.usage.annotation;
+
+import com.cvmento.global.usage.enums.UsageType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 통합 토큰 사용을 요구하는 메서드에 붙이는 어노테이션
+ */
+@Target(ElementType.METHOD)  // 메서드에만 붙일 수 있음
+@Retention(RetentionPolicy.RUNTIME)  // 런타임에 리플렉션으로 읽을 수 있음
+public @interface RequireTokens {  // @interface로 어노테이션 정의
+
+    /**
+     * 사용량 타입 (토큰 소모량이 결정됨)
+     * value 속성은 사용 시 생략 가능: @RequireTokens(UsageType.ESSAY_REVIEW)
+     */
+    UsageType value();  // 필수 속성, 메서드 형태로 정의
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/config/UsageInterceptorConfig.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/config/UsageInterceptorConfig.java
@@ -1,0 +1,27 @@
+package com.cvmento.global.usage.config;
+
+import com.cvmento.global.usage.interceptor.UsageLimitInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * 사용량 제한 인터셉터 설정
+ */
+@Configuration
+@RequiredArgsConstructor
+public class UsageInterceptorConfig implements WebMvcConfigurer {
+
+    private final UsageLimitInterceptor usageLimitInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(usageLimitInterceptor)
+                .addPathPatterns(
+                        "/api/v1/cover-letters/**",  // 자소서 관련
+                        "/api/v1/me/cover-letters/{coverLetterId}/interview-questions/**",  // 면접 관련
+                        "/api/v1/resumes/**"  // 이력서 관련
+                );
+    }
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/controller/UsageController.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/controller/UsageController.java
@@ -1,11 +1,14 @@
 package com.cvmento.global.usage.controller;
 
-import com.cvmento.domain.auth.service.AuthService;
 import com.cvmento.global.common.dto.CommonResponse;
 import com.cvmento.global.usage.dto.TokenUsageInfo;
 import com.cvmento.global.usage.service.UsageTokenService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,10 +28,77 @@ public class UsageController {
 
     @Operation(
             summary = "현재 토큰 사용량 조회",
-            description = "사용자의 현재 토큰 보유량, 최대 토큰 수, 다음 충전 시간 등을 조회합니다."
+            description = """
+                사용자의 현재 토큰 보유량과 관련 정보를 조회합니다.
+                
+                토큰은 다양한 AI 기능 사용 시 소모됩니다. 각 기능별 소모량은 상이하며,
+                주기적으로 자동 충전됩니다.
+                """
     )
-    @ApiResponse(responseCode = "200", description = "토큰 사용량 조회 성공")
-    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "토큰 사용량 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommonResponse.class),
+                            examples = @ExampleObject(
+                                    name = "성공 응답 예시",
+                                    value = """
+                    {
+                        "success": true,
+                        "message": "토큰 사용량 조회 성공",
+                        "data": {
+                            "remainingTokens": 75,
+                            "maxTokens": 100,
+                            "nextRefillTime": "2025-09-10T09:00:00",
+                            "refillAmount": 25
+                        },
+                        "errorCode": null,
+                        "canRetry": null,
+                        "timestamp": "2025-09-09T10:30:00"
+                    }
+                    """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "timestamp": "2025-09-09T10:30:00",
+                        "status": 401,
+                        "error": "Unauthorized",
+                        "message": "인증이 필요합니다"
+                    }
+                    """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                    {
+                        "timestamp": "2025-09-09T10:30:00",
+                        "status": 404,
+                        "error": "Not Found",
+                        "errorCode": "MEMBER_NOT_FOUND",
+                        "message": "사용자를 찾을 수 없습니다",
+                        "errors": {}
+                    }
+                    """
+                            )
+                    )
+            )
+    })
     @GetMapping("/tokens")
     public ResponseEntity<CommonResponse<TokenUsageInfo>> getTokenUsage(
             @AuthenticationPrincipal UserDetails userDetails

--- a/CVMento/src/main/java/com/cvmento/global/usage/controller/UsageController.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/controller/UsageController.java
@@ -1,0 +1,41 @@
+package com.cvmento.global.usage.controller;
+
+import com.cvmento.domain.auth.service.AuthService;
+import com.cvmento.global.common.dto.CommonResponse;
+import com.cvmento.global.usage.dto.TokenUsageInfo;
+import com.cvmento.global.usage.service.UsageTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "토큰 사용량 관리", description = "토큰 사용량 조회 및 관리 API")
+@RestController
+@RequestMapping("/api/v1/usage")
+@RequiredArgsConstructor
+public class UsageController {
+
+    private final UsageTokenService usageTokenService;
+
+    @Operation(
+            summary = "현재 토큰 사용량 조회",
+            description = "사용자의 현재 토큰 보유량, 최대 토큰 수, 다음 충전 시간 등을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "토큰 사용량 조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    @GetMapping("/tokens")
+    public ResponseEntity<CommonResponse<TokenUsageInfo>> getTokenUsage(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String email = userDetails.getUsername();
+        TokenUsageInfo tokenUsage = usageTokenService.getTokenUsage(email);
+
+        return ResponseEntity.ok(CommonResponse.success("토큰 사용량 조회 성공", tokenUsage));
+    }
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/dto/TokenUsageInfo.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/dto/TokenUsageInfo.java
@@ -1,0 +1,24 @@
+package com.cvmento.global.usage.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 통합 토큰 사용량 정보 DTO
+ */
+@Builder
+public record TokenUsageInfo(
+        int remainingTokens,      // 남은 토큰 수
+        int maxTokens,           // 최대 토큰 수
+        LocalDateTime nextRefillTime, // 다음 충전 시간
+        int refillAmount         // 충전 시 증가량
+) {
+
+    public static TokenUsageInfo empty() {
+        return TokenUsageInfo.builder()
+                .remainingTokens(0)
+                .maxTokens(0)
+                .build();
+    }
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/enums/UsageType.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/enums/UsageType.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
  */
 @Getter
 public enum UsageType {
-    ESSAY_REVIEW("AI 자소서 첨삭", 5),           // 5토큰 소모
+    COVERLETTER_REVIEW("AI 자소서 첨삭", 5),           // 5토큰 소모
     INTERVIEW_AUTO("모의 면접 자동질문생성", 3),    // 3토큰 소모
     INTERVIEW_CUSTOM("커스텀 프롬프트 면접 답변생성", 1);       // 1토큰 소모
 

--- a/CVMento/src/main/java/com/cvmento/global/usage/enums/UsageType.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/enums/UsageType.java
@@ -8,9 +8,9 @@ import java.time.LocalDateTime;
  */
 @Getter
 public enum UsageType {
-    ESSAY_REVIEW("자소서 첨삭", 5),           // 5토큰 소모
-    INTERVIEW_AUTO("자소서 기반 면접", 10),    // 10토큰 소모
-    INTERVIEW_CUSTOM("커스텀 면접", 3);       // 3토큰 소모
+    ESSAY_REVIEW("AI 자소서 첨삭", 5),           // 5토큰 소모
+    INTERVIEW_AUTO("모의 면접 자동질문생성", 3),    // 3토큰 소모
+    INTERVIEW_CUSTOM("커스텀 프롬프트 면접 답변생성", 1);       // 1토큰 소모
 
     // ===== 인스턴스 필드 =====
     private final String description;
@@ -23,9 +23,9 @@ public enum UsageType {
     }
 
     // ===== 통합 토큰 설정 상수 =====
-    public static final int MAX_TOKENS = 20;                    // 최대 20개
+    public static final int MAX_TOKENS = 40;                    // 최대 40개
     public static final int REFILL_INTERVAL_HOURS = 2;          // 2시간마다
-    public static final int REFILL_AMOUNT = 5;                  // 5개씩 충전
+    public static final int REFILL_AMOUNT = 10;                  // 10개씩 충전
 
     // ===== Redis 키 생성 메서드 =====
     /**

--- a/CVMento/src/main/java/com/cvmento/global/usage/enums/UsageType.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/enums/UsageType.java
@@ -1,0 +1,69 @@
+package com.cvmento.global.usage.enums;
+
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+/**
+ * 사용량 타입 정의 (통합 토큰 시스템 - 고정 충전 시점)
+ */
+@Getter
+public enum UsageType {
+    ESSAY_REVIEW("자소서 첨삭", 5),           // 5토큰 소모
+    INTERVIEW_AUTO("자소서 기반 면접", 10),    // 10토큰 소모
+    INTERVIEW_CUSTOM("커스텀 면접", 3);       // 3토큰 소모
+
+    // ===== 인스턴스 필드 =====
+    private final String description;
+    private final int cost;
+
+    // ===== 생성자 =====
+    UsageType(String description, int cost) {
+        this.description = description;
+        this.cost = cost;
+    }
+
+    // ===== 통합 토큰 설정 상수 =====
+    public static final int MAX_TOKENS = 20;                    // 최대 20개
+    public static final int REFILL_INTERVAL_HOURS = 2;          // 2시간마다
+    public static final int REFILL_AMOUNT = 5;                  // 5개씩 충전
+
+    // ===== Redis 키 생성 메서드 =====
+    /**
+     * 사용자별 토큰 Redis 키 생성
+     */
+    public static String getTokenKey(Long userId) {
+        return String.format("user:%d:tokens", userId);
+    }
+
+    /**
+     * 전역 마지막 충전 시간 Redis 키
+     */
+    public static String getGlobalLastRefillKey() {
+        return "global:last_refill_time";
+    }
+
+    // ===== 충전 시간 관련 메서드 =====
+    /**
+     * 다음 고정 충전 시간 계산
+     * 매일 00:00, 02:00, 04:00, 06:00... 시점에 충전
+     */
+    public static LocalDateTime getNextRefillTime() {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 현재 시간을 2시간 단위로 올림
+        int currentHour = now.getHour();
+        int nextRefillHour = ((currentHour / REFILL_INTERVAL_HOURS) + 1) * REFILL_INTERVAL_HOURS;
+
+        LocalDateTime nextRefill = now.withMinute(0).withSecond(0).withNano(0);
+
+        if (nextRefillHour >= 24) {
+            // 다음 날 00:00
+            nextRefill = nextRefill.plusDays(1).withHour(0);
+        } else {
+            nextRefill = nextRefill.withHour(nextRefillHour);
+        }
+
+        return nextRefill;
+    }
+
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/interceptor/UsageLimitInterceptor.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/interceptor/UsageLimitInterceptor.java
@@ -1,0 +1,71 @@
+package com.cvmento.global.usage.interceptor;
+
+import com.cvmento.domain.member.entity.Member;
+import com.cvmento.domain.member.repository.MemberRepository;
+import com.cvmento.global.usage.annotation.RequireTokens;
+import com.cvmento.global.usage.service.UsageTokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * 통합 토큰 사용량 제한 인터셉터 (고정 시점 충전 방식)
+ * @RequireTokens 어노테이션이 붙은 메서드의 토큰 사용량을 체크합니다.
+ * 토큰 충전은 스케줄러가 담당하므로 여기서는 소모만 처리합니다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UsageLimitInterceptor implements HandlerInterceptor {
+
+    private final UsageTokenService usageTokenService;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+
+        // HandlerMethod가 아니면 통과 (정적 리소스 등)
+        if (!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+
+        // @RequireTokens 어노테이션 체크
+        RequireTokens requireTokens = handlerMethod.getMethodAnnotation(RequireTokens.class);
+        if (requireTokens == null) {
+            return true; // 어노테이션이 없으면 통과
+        }
+
+        // 스프링 시큐리티에서 이미 인증 체크했으므로 바로 사용자 정보 추출
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+        try {
+            // 사용자 이메일로 Member 조회
+            String userEmail = userDetails.getUsername();
+            Member member = memberRepository.findByEmail(userEmail)
+                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userEmail));
+
+            // 토큰 소모 시도 (충전 로직 없음, 스케줄러가 담당)
+            usageTokenService.tryConsumeTokens(member.getMemberId(), requireTokens.value());
+
+            log.info("토큰 소모 성공 - 사용자: {}, 기능: {}, 소모량: {}개, API: {}",
+                    member.getMemberId(), requireTokens.value().getDescription(),
+                    requireTokens.value().getCost(), request.getRequestURI());
+
+            return true;
+
+        } catch (Exception e) {
+            log.error("토큰 사용량 체크 중 오류 발생", e);
+            // UsageLimitExceededException은 GlobalExceptionHandler에서 처리하도록 던짐
+            throw e;
+        }
+    }
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/scheduler/TokenRefillScheduler.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/scheduler/TokenRefillScheduler.java
@@ -1,0 +1,29 @@
+package com.cvmento.global.usage.scheduler;
+
+import com.cvmento.global.usage.service.UsageTokenService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 고정 시점 토큰 충전 스케줄러
+ * 매 2시간마다 (00:00, 02:00, 04:00...) 모든 사용자에게 토큰 충전
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TokenRefillScheduler {
+
+    private final UsageTokenService usageTokenService;
+
+    /**
+     * 매 시간 정각에 실행하여 충전 시점인지 확인
+     * 2시간마다 (짝수 시간)일 때만 실제 충전 수행
+     */
+    @Scheduled(cron = "0 0 */2 * * *") // 매 2시간마다 (00:00, 02:00, 04:00, ...)
+    public void refillAllUserTokens() {
+        log.info("고정 시점 토큰 충전 시작");
+        usageTokenService.refillAllUsersTokens();
+    }
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/service/NewUserTokenInitializer.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/service/NewUserTokenInitializer.java
@@ -1,0 +1,66 @@
+package com.cvmento.global.usage.service;
+
+import com.cvmento.domain.member.entity.Member;
+import com.cvmento.domain.member.enums.UserStatus;
+import com.cvmento.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 신규 사용자 토큰 초기화 (고정 시점 충전 방식)
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NewUserTokenInitializer {
+
+    private final UsageTokenService usageTokenService;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 애플리케이션 시작 시 기존 활성 사용자들의 토큰 초기화
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void initializeExistingUsersTokens() {
+        try {
+            List<Member> activeMembers = memberRepository.findByStatus(UserStatus.ACTIVE);
+
+            log.info("기존 활성 사용자 토큰 초기화 시작 - 대상 사용자 수: {}", activeMembers.size());
+
+            int successCount = 0;
+            for (Member member : activeMembers) {
+                try {
+                    // 사용자별 토큰 초기화 시도
+                    usageTokenService.initializeUserTokens(member.getMemberId());
+                    successCount++;
+                } catch (Exception e) {
+                    log.error("사용자 토큰 초기화 실패 - 사용자 ID: {}, 에러: {}",
+                            member.getMemberId(), e.getMessage());
+                }
+            }
+
+            log.info("기존 사용자 토큰 초기화 완료 - 성공: {}/{}", successCount, activeMembers.size());
+
+        } catch (Exception e) {
+            log.error("기존 사용자 토큰 초기화 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 신규 가입 사용자 토큰 초기화
+     * 회원가입 시점에 호출
+     */
+    public void initializeNewUserTokens(Long userId) {
+        try {
+            usageTokenService.initializeUserTokens(userId);
+            log.info("신규 사용자 토큰 초기화 완료 - 사용자 ID: {}", userId);
+        } catch (Exception e) {
+            log.error("신규 사용자 토큰 초기화 실패 - 사용자 ID: {}, 에러: {}", userId, e.getMessage());
+        }
+    }
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/service/UsageTokenService.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/service/UsageTokenService.java
@@ -52,7 +52,7 @@ public class UsageTokenService {
             // 현재 3개, 필요 5개 → 부족!
             LocalDateTime nextRefillTime = UsageType.getNextRefillTime();
             // 다음 충전 시간: "2025-09-08T16:00:00"
-            throw new UsageLimitExceededException(usageType, 3, 5, nextRefillTime);
+            throw new UsageLimitExceededException(usageType, currentTokens, requiredTokens, nextRefillTime);
             // 예외 발생 → GlobalExceptionHandler가 429 에러 응답
         }
 

--- a/CVMento/src/main/java/com/cvmento/global/usage/service/UsageTokenService.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/service/UsageTokenService.java
@@ -1,0 +1,157 @@
+package com.cvmento.global.usage.service;
+
+import com.cvmento.domain.member.entity.Member;
+import com.cvmento.domain.member.repository.MemberRepository;
+import com.cvmento.global.usage.dto.TokenUsageInfo;
+import com.cvmento.global.usage.enums.UsageType;
+import com.cvmento.global.exception.customException.UsageLimitExceededException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+/**
+ * 통합 토큰 사용량 관리 서비스 (고정 충전 시점)
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UsageTokenService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 토큰 소모 시도
+     *
+     * @param memberId    사용자 ID
+     * @param usageType 사용량 타입 (소모량이 결정됨)
+     * @throws UsageLimitExceededException 토큰 부족 시
+     */
+    public void tryConsumeTokens(Long memberId, UsageType usageType) {
+        // 사용자 토큰 키 생성
+        String tokenKey = UsageType.getTokenKey(memberId);
+        // 현재 토큰 조회
+        Integer currentTokens = (Integer) redisTemplate.opsForValue().get(tokenKey);
+
+        // 첫 사용자 체크 (안전장치)
+        if (currentTokens == null) {
+            // 첫 사용자면 최대 토큰으로 초기화
+            initializeUserTokens(memberId);
+            currentTokens = UsageType.MAX_TOKENS;
+        }
+
+        // 필요 토큰 계산
+        int requiredTokens = usageType.getCost();
+
+        // 토큰 부족 체크
+        if (currentTokens < requiredTokens) {
+            // 현재 3개, 필요 5개 → 부족!
+            LocalDateTime nextRefillTime = UsageType.getNextRefillTime();
+            // 다음 충전 시간: "2025-09-08T16:00:00"
+            throw new UsageLimitExceededException(usageType, 3, 5, nextRefillTime);
+            // 예외 발생 → GlobalExceptionHandler가 429 에러 응답
+        }
+
+        // 토큰 차감
+        Long remaining = redisTemplate.opsForValue().decrement(tokenKey, requiredTokens);
+
+        log.info("토큰 소모 - 사용자: {}, 기능: {}, 소모량: {}, 남은량: {}",
+                memberId, usageType.getDescription(), requiredTokens, remaining);
+    }
+
+    /**
+     * 사용자의 토큰 사용량 조회 (이메일 기반)
+     */
+    public TokenUsageInfo getTokenUsage(String userEmail) {
+        // 이메일로 Member 조회
+        Member member = memberRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userEmail));
+
+        // 사용자 토큰 키 생성
+        String tokenKey = UsageType.getTokenKey(member.getMemberId());
+        // 현재 토큰 조회
+        Integer currentTokens = (Integer) redisTemplate.opsForValue().get(tokenKey);
+
+        // 첫 사용자 체크 (안전장치)
+        if (currentTokens == null) {
+            initializeUserTokens(member.getMemberId());
+            currentTokens = UsageType.MAX_TOKENS;
+        }
+
+        // 토큰 정보 반환
+        return TokenUsageInfo.builder()
+                .remainingTokens(currentTokens)
+                .maxTokens(UsageType.MAX_TOKENS)
+                .nextRefillTime(UsageType.getNextRefillTime())
+                .refillAmount(UsageType.REFILL_AMOUNT)
+                .build();
+    }
+
+    /**
+     * 사용자 토큰 초기화 (신규 가입자 또는 서버 시작 시)
+     */
+    public void initializeUserTokens(Long memberId) {
+        // 사용자 토큰 키 생성
+        String tokenKey = UsageType.getTokenKey(memberId);
+
+        // 최대 토큰으로 설정
+        redisTemplate.opsForValue().set(tokenKey, UsageType.MAX_TOKENS);
+
+        log.info("사용자 토큰 초기화 완료 - 사용자 ID: {}, 토큰: {}개", memberId, UsageType.MAX_TOKENS);
+    }
+
+    /**
+     * 전체 사용자 토큰 충전 (스케줄러 전용)
+     * 고정 시점(매 2시간)에 모든 사용자에게 토큰 충전
+     */
+    public void refillAllUsersTokens() {
+        try {
+            log.info("전체 사용자 토큰 충전 시작 - 시간: {}", LocalDateTime.now());
+
+            // 모든 사용자 토큰 키 검색
+            String pattern = "user:*:tokens";
+            var tokenKeys = redisTemplate.keys(pattern);
+
+            if (tokenKeys.isEmpty()) {
+                log.info("충전할 사용자 토큰이 없습니다.");
+                return;
+            }
+
+            int processedCount = 0;
+            for (String tokenKey : tokenKeys) {
+                try {
+                    // 현재 토큰 조회
+                    Integer currentTokens = (Integer) redisTemplate.opsForValue().get(tokenKey);
+                    // 토큰이 null이 아니고 최대치 미만인 경우에만 충전
+                    if (currentTokens != null && currentTokens < UsageType.MAX_TOKENS) {
+                        // 충전 후 토큰 계산
+                        int newTokenCount = Math.min(currentTokens + UsageType.REFILL_AMOUNT, UsageType.MAX_TOKENS);
+                        redisTemplate.opsForValue().set(tokenKey, newTokenCount);
+
+                        // 사용자 ID 추출해서 로깅
+                        String[] parts = tokenKey.split(":");
+                        if (parts.length >= 2) {
+                            log.debug("토큰 충전 - 사용자: {}, {}개 → {}개",
+                                    parts[1], currentTokens, newTokenCount);
+                        }
+                        processedCount++;
+                    }
+                } catch (Exception e) {
+                    log.warn("토큰 충전 실패 - 키: {}, 에러: {}", tokenKey, e.getMessage());
+                }
+            }
+
+            // 전역 마지막 충전 시간 업데이트
+            redisTemplate.opsForValue().set(UsageType.getGlobalLastRefillKey(),
+                    LocalDateTime.now().toString());
+
+            log.info("전체 사용자 토큰 충전 완료 - 처리된 사용자: {}명", processedCount);
+
+        } catch (Exception e) {
+            log.error("전체 토큰 충전 중 오류 발생", e);
+        }
+    }
+}

--- a/CVMento/src/main/java/com/cvmento/global/usage/service/UsageTokenService.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/service/UsageTokenService.java
@@ -2,6 +2,7 @@ package com.cvmento.global.usage.service;
 
 import com.cvmento.domain.member.entity.Member;
 import com.cvmento.domain.member.repository.MemberRepository;
+import com.cvmento.global.exception.customException.MemberNotFoundException;
 import com.cvmento.global.usage.dto.TokenUsageInfo;
 import com.cvmento.global.usage.enums.UsageType;
 import com.cvmento.global.exception.customException.UsageLimitExceededException;
@@ -68,7 +69,7 @@ public class UsageTokenService {
     public TokenUsageInfo getTokenUsage(String userEmail) {
         // 이메일로 Member 조회
         Member member = memberRepository.findByEmail(userEmail)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userEmail));
+                .orElseThrow(() -> new MemberNotFoundException("사용자를 찾을 수 없습니다: " + userEmail));
 
         // 사용자 토큰 키 생성
         String tokenKey = UsageType.getTokenKey(member.getMemberId());

--- a/CVMento/src/main/java/com/cvmento/global/usage/util/TokenResponseUtil.java
+++ b/CVMento/src/main/java/com/cvmento/global/usage/util/TokenResponseUtil.java
@@ -1,0 +1,39 @@
+package com.cvmento.global.usage.util;
+
+import com.cvmento.global.usage.dto.TokenUsageInfo;
+import com.cvmento.global.usage.service.UsageTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * 응답에 토큰 사용량 정보를 포함시키는 유틸리티
+ */
+@Component
+@RequiredArgsConstructor
+public class TokenResponseUtil {
+
+    private final UsageTokenService usageTokenService;
+
+    // 추후 추가 구현 부분
+
+    /**
+     * 응답 데이터에 토큰 사용량 정보를 추가 (이메일 기반)
+     */
+    public Map<String, Object> addTokenUsage(String userEmail, Object responseData) {
+        TokenUsageInfo tokenUsage = usageTokenService.getTokenUsage(userEmail);
+
+        return Map.of(
+                "data", responseData,
+                "tokenUsage", tokenUsage
+        );
+    }
+
+    /**
+     * 토큰 사용량 정보만 반환 (이메일 기반)
+     */
+    public TokenUsageInfo getTokenUsage(String userEmail) {
+        return usageTokenService.getTokenUsage(userEmail);
+    }
+}

--- a/CVMento/src/main/resources/application-test.yml
+++ b/CVMento/src/main/resources/application-test.yml
@@ -12,8 +12,8 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6379
-      password: test
+      port: 6381
+      password: team2
       timeout: 2000ms
   cloud:
     openfeign:

--- a/CVMento/src/main/resources/application.yml
+++ b/CVMento/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     name: backend
   profiles:
     active: local  # 기본 프로파일
+  jackson:
+    time-zone: Asia/Seoul
 
   # 공통 설정
   servlet:

--- a/CVMento/src/test/java/com/cvmento/domain/interview/service/InterviewServiceTest.java
+++ b/CVMento/src/test/java/com/cvmento/domain/interview/service/InterviewServiceTest.java
@@ -14,7 +14,6 @@ import com.cvmento.domain.member.repository.MemberRepository;
 import com.cvmento.global.exception.customException.CoverLetterException;
 import com.cvmento.global.exception.customException.InterviewException;
 import com.cvmento.global.exception.customException.InterviewLimitExceededException;
-import com.cvmento.global.exception.customException.MemberNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,11 +35,11 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 /**
- * InterviewService의 단위 테스트 (상세 로깅 버전)
+ * InterviewService의 단위 테스트
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("InterviewService 단위 테스트")
-@Slf4j  // 로깅을 위한 어노테이션
+@Slf4j
 class InterviewServiceTest {
 
     @Mock
@@ -99,18 +98,16 @@ class InterviewServiceTest {
             List<CoverLetterQna> existingQnas = createMockQnaList(5);
             log.info("생성된 가짜 질문 개수: {}", existingQnas.size());
 
-            // Mock 설정 로깅
-            given(memberRepository.findByEmail(userEmail))
-                    .willReturn(Optional.of(testMember));
-            log.info("Mock 설정: memberRepository.findByEmail({}) -> testMember 반환", userEmail);
-
-            given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, testMember))
+            // 실제 서비스 로직에 맞춘 Mock 설정
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
                     .willReturn(Optional.of(testCoverLetter));
-            log.info("Mock 설정: coverLetterRepository.findByCoverLetterIdAndMember({}, testMember) -> testCoverLetter 반환", coverLetterId);
+            log.info("Mock 설정: coverLetterRepository.findByCoverLetterIdAndMemberEmail({}, {}) -> testCoverLetter 반환",
+                    coverLetterId, userEmail);
 
             given(coverLetterQnaRepository.findByCoverLetterOrderByCreatedAtAsc(testCoverLetter))
                     .willReturn(existingQnas);
-            log.info("Mock 설정: coverLetterQnaRepository.findByCoverLetterOrderByCreatedAtAsc(testCoverLetter) -> {}개 질문 반환", existingQnas.size());
+            log.info("Mock 설정: coverLetterQnaRepository.findByCoverLetterOrderByCreatedAtAsc(testCoverLetter) -> {}개 질문 반환",
+                    existingQnas.size());
 
             // when
             log.info("=== 메서드 실행 ===");
@@ -138,9 +135,7 @@ class InterviewServiceTest {
             log.info("=== 테스트 시작: 기존 질문이 없을 때 빈 배열 반환 ===");
 
             // given
-            given(memberRepository.findByEmail(userEmail))
-                    .willReturn(Optional.of(testMember));
-            given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, testMember))
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
                     .willReturn(Optional.of(testCoverLetter));
             given(coverLetterQnaRepository.findByCoverLetterOrderByCreatedAtAsc(testCoverLetter))
                     .willReturn(new ArrayList<>());
@@ -160,21 +155,22 @@ class InterviewServiceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 사용자일 때 예외 발생")
-        void shouldThrowExceptionWhenMemberNotFound() {
-            log.info("=== 테스트 시작: 존재하지 않는 사용자일 때 예외 발생 ===");
+        @DisplayName("존재하지 않는 자소서일 때 예외 발생")
+        void shouldThrowExceptionWhenCoverLetterNotFound() {
+            log.info("=== 테스트 시작: 존재하지 않는 자소서일 때 예외 발생 ===");
 
             // given
-            given(memberRepository.findByEmail(userEmail))
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
                     .willReturn(Optional.empty());
-            log.info("Mock 설정: memberRepository.findByEmail({}) -> Optional.empty() 반환", userEmail);
+            log.info("Mock 설정: coverLetterRepository.findByCoverLetterIdAndMemberEmail({}, {}) -> Optional.empty() 반환",
+                    coverLetterId, userEmail);
 
             // when & then
-            log.info("예외 발생 예상 - MemberNotFoundException");
+            log.info("예외 발생 예상 - CoverLetterException");
             assertThatThrownBy(() ->
                     interviewService.getExistingInterviewQna(coverLetterId, userEmail))
-                    .isInstanceOf(MemberNotFoundException.class)
-                    .hasMessage("사용자를 찾을 수 없습니다.");
+                    .isInstanceOf(CoverLetterException.class)
+                    .hasMessage("자소서를 찾을 수 없습니다.");
             log.info("✅ 예상된 예외 발생 확인");
             log.info("=== 테스트 완료 ===\n");
         }
@@ -187,11 +183,9 @@ class InterviewServiceTest {
         @BeforeEach
         void setUp() {
             log.info("--- CreateInterviewQuestionsTest 공통 Mock 설정 ---");
-            given(memberRepository.findByEmail(userEmail))
-                    .willReturn(Optional.of(testMember));
-            given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, testMember))
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
                     .willReturn(Optional.of(testCoverLetter));
-            log.info("Member와 CoverLetter 조회 Mock 설정 완료\n");
+            log.info("CoverLetter 조회 Mock 설정 완료\n");
         }
 
         @Test
@@ -454,9 +448,9 @@ class InterviewServiceTest {
         }
 
         @Test
-        @DisplayName("LLM이 JSON이 아닌 응답을 보낼 때")
-        void shouldThrowExceptionWhenLlmReturnsInvalidJson() {
-            log.info("=== 테스트 시작: LLM이 JSON이 아닌 응답을 보낼 때 ===");
+        @DisplayName("LLM 서비스 실패시 예외 발생")
+        void shouldThrowExceptionWhenLlmServiceFails() {
+            log.info("=== 테스트 시작: LLM 서비스 실패시 예외 발생 ===");
 
             // given
             String customQuestion = "테스트 질문";
@@ -466,10 +460,10 @@ class InterviewServiceTest {
                     .willReturn(mockPrompt);
             log.info("Mock 설정: 프롬프트 생성");
 
-            // LLM이 일반 텍스트 응답을 보내는 상황
+            RuntimeException llmException = new RuntimeException("LLM 서비스 실패");
             given(llmClientService.generateCustomAnswer(mockPrompt))
-                    .willThrow(new InterviewException("커스텀 답변 데이터 파싱에 실패했습니다."));
-            log.info("Mock 설정: LLM이 파싱 불가능한 응답 반환");
+                    .willThrow(llmException);
+            log.info("Mock 설정: LLM 서비스에서 예외 발생 - '{}'", llmException.getMessage());
 
             // when & then
             log.info("예외 발생 예상 - InterviewException");
@@ -477,46 +471,13 @@ class InterviewServiceTest {
                     interviewService.createCustomAnswer(coverLetterId, userEmail, customQuestion))
                     .isInstanceOf(InterviewException.class)
                     .hasMessage("커스텀 질문 답변 생성에 실패했습니다.");
-            log.info("✅ 예상된 JSON 파싱 예외 발생 확인");
+            log.info("✅ 예상된 InterviewException 발생 확인");
 
             verify(coverLetterQnaRepository, never()).save(any());
-            log.info("✅ 저장 메서드가 호출되지 않음을 확인 (파싱 실패로 인해)");
+            log.info("✅ 저장 메서드가 호출되지 않음을 확인 (LLM 실패로 인해)");
 
             log.info("=== 테스트 완료 ===\n");
         }
-
-        @Test
-        @DisplayName("LLM 응답에 answer 필드가 없을 때")
-        void shouldThrowExceptionWhenAnswerFieldMissing() {
-            log.info("=== 테스트 시작: LLM 응답에 answer 필드가 없을 때 ===");
-
-            // given
-            String customQuestion = "테스트 질문";
-            String mockPrompt = "프롬프트";
-
-            given(promptService.buildCustomAnswerPrompt(testCoverLetter, customQuestion))
-                    .willReturn(mockPrompt);
-            log.info("Mock 설정: 프롬프트 생성");
-
-            // LLM이 answer 필드가 누락된 응답을 보내는 상황
-            given(llmClientService.generateCustomAnswer(mockPrompt))
-                    .willThrow(new InterviewException("커스텀 답변 데이터 파싱에 실패했습니다."));
-            log.info("Mock 설정: LLM이 answer 필드 누락된 응답 반환");
-
-            // when & then
-            log.info("예외 발생 예상 - InterviewException");
-            assertThatThrownBy(() ->
-                    interviewService.createCustomAnswer(coverLetterId, userEmail, customQuestion))
-                    .isInstanceOf(InterviewException.class)
-                    .hasMessage("커스텀 질문 답변 생성에 실패했습니다.");
-            log.info("✅ 예상된 필드 누락 예외 발생 확인");
-
-            verify(coverLetterQnaRepository, never()).save(any());
-            log.info("✅ 저장 메서드가 호출되지 않음을 확인 (필드 누락으로 인해)");
-
-            log.info("=== 테스트 완료 ===\n");
-        }
-
     }
 
     // ================ 테스트 헬퍼 메서드들 ================

--- a/CVMento/src/test/java/com/cvmento/global/usage/service/UsageTokenServiceRedisIntegrationTest.java
+++ b/CVMento/src/test/java/com/cvmento/global/usage/service/UsageTokenServiceRedisIntegrationTest.java
@@ -131,8 +131,8 @@ class UsageTokenServiceRedisIntegrationTest {
             log.info("초기 토큰 설정 완료: {}개", UsageType.MAX_TOKENS);
 
             // when
-            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.ESSAY_REVIEW);
-            log.info("토큰 소모 실행: ESSAY_REVIEW (5토큰)");
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.COVERLETTER_REVIEW);
+            log.info("토큰 소모 실행: COVERLETTER_REVIEW (5토큰)");
 
             // then
             Integer remainingTokens = (Integer) redisTemplate.opsForValue().get(tokenKey);
@@ -234,7 +234,7 @@ class UsageTokenServiceRedisIntegrationTest {
             log.info("2명 사용자 토큰 초기화 완료");
 
             // when
-            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.ESSAY_REVIEW); // 5토큰
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.COVERLETTER_REVIEW); // 5토큰
             usageTokenService.tryConsumeTokens(user2.getMemberId(), UsageType.INTERVIEW_AUTO); // 3토큰
 
             // then
@@ -272,7 +272,7 @@ class UsageTokenServiceRedisIntegrationTest {
             usageTokenService.initializeUserTokens(user2.getMemberId());
 
             usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.INTERVIEW_AUTO); // 3토큰 소모 -> 37
-            usageTokenService.tryConsumeTokens(user2.getMemberId(), UsageType.ESSAY_REVIEW); // 5토큰 소모 -> 35
+            usageTokenService.tryConsumeTokens(user2.getMemberId(), UsageType.COVERLETTER_REVIEW); // 5토큰 소모 -> 35
 
             log.info("초기 설정 완료: user1=37토큰, user2=35토큰");
 
@@ -331,7 +331,7 @@ class UsageTokenServiceRedisIntegrationTest {
 
             // given
             String tokenKey = UsageType.getTokenKey(testMember.getMemberId());
-            UsageType usageType = UsageType.ESSAY_REVIEW; // 5토큰 필요
+            UsageType usageType = UsageType.COVERLETTER_REVIEW; // 5토큰 필요
             redisTemplate.opsForValue().set(tokenKey, usageType.getCost()); // 정확히 5토큰 설정
             log.info("토큰을 정확히 {}개로 설정", usageType.getCost());
 
@@ -364,7 +364,7 @@ class UsageTokenServiceRedisIntegrationTest {
             log.info("1단계 - 신규 가입: {}토큰 초기화", step1.remainingTokens());
 
             // 2. 여러 기능 사용
-            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.ESSAY_REVIEW); // 5토큰
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.COVERLETTER_REVIEW); // 5토큰
             usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.INTERVIEW_AUTO); // 3토큰
             usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.INTERVIEW_CUSTOM); // 1토큰
 
@@ -379,7 +379,7 @@ class UsageTokenServiceRedisIntegrationTest {
             log.info("3단계 - 토큰 충전: 31 + 10 = 41 -> {}토큰 (최대값 제한)", step3.remainingTokens());
 
             // 4. 다시 사용
-            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.ESSAY_REVIEW); // 5토큰
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.COVERLETTER_REVIEW); // 5토큰
             TokenUsageInfo step4 = usageTokenService.getTokenUsage(TEST_EMAIL);
             assertThat(step4.remainingTokens()).isEqualTo(35);
             log.info("4단계 - 추가 사용: 40 -> {}토큰 (5토큰 소모)", step4.remainingTokens());

--- a/CVMento/src/test/java/com/cvmento/global/usage/service/UsageTokenServiceRedisIntegrationTest.java
+++ b/CVMento/src/test/java/com/cvmento/global/usage/service/UsageTokenServiceRedisIntegrationTest.java
@@ -1,0 +1,391 @@
+package com.cvmento.global.usage.service;
+
+import com.cvmento.domain.member.entity.Member;
+import com.cvmento.domain.member.repository.MemberRepository;
+import com.cvmento.global.usage.dto.TokenUsageInfo;
+import com.cvmento.global.usage.enums.UsageType;
+import com.cvmento.global.exception.customException.UsageLimitExceededException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * UsageTokenService Redis 통합 테스트
+ *
+ * 목적: 실제 Redis와의 연동 안정성 및 데이터 일관성 검증
+ * 방식: 실제 Redis 인스턴스 사용, 진짜 데이터 저장/조회
+ *
+ * 검증 내용:
+ * 1. 기본 Redis 연동 - 실제 저장, 조회, 소모 동작 확인
+ * 2. 동시성 테스트 - 멀티스레드 환경에서 Redis 원자적 연산(DECRBY) 검증
+ * 3. 사용자 격리 - 여러 사용자가 독립적으로 토큰 관리되는지 확인
+ * 4. 전체 사용자 충전 - 실제 Redis keys 패턴 검색 및 배치 업데이트
+ * 5. 경계값 처리 - 0토큰, 정확한 토큰량에서의 동작
+ * 6. 실제 사용자 여정 - 가입 → 사용 → 충전 → 재사용 전체 플로우
+ *
+ * 특징:
+ * - @SpringBootTest로 실제 컨텍스트 로딩
+ * - 개발용 Redis 서버 직접 사용
+ * - @AfterEach에서 테스트 키 정리 (user:*, global:*)
+ * - 동시성 안전성 검증 (Race Condition 방지)
+ * - 실제 운영 환경과 동일한 조건에서 테스트
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@Slf4j
+class UsageTokenServiceRedisIntegrationTest {
+
+    @Autowired
+    private UsageTokenService usageTokenService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    private Member testMember;
+    private final String TEST_EMAIL = "redis-test@example.com";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        log.info("=== Redis 통합 테스트 설정 시작 ===");
+
+        // 테스트 사용자 생성
+        testMember = new Member("google-redis-test", TEST_EMAIL, "Redis통합테스트사용자", "profile.jpg");
+        testMember = memberRepository.save(testMember);
+        log.info("테스트 Member 생성: email={}, memberId={}", TEST_EMAIL, testMember.getMemberId());
+
+        log.info("=== Redis 통합 테스트 설정 완료 ===\n");
+    }
+
+    @AfterEach
+    void tearDown() {
+        log.info("=== Redis 테스트 데이터 정리 시작 ===");
+
+        // user:로 시작하는 모든 키 삭제
+        Set<String> userKeys = redisTemplate.keys("user:*");
+        Set<String> globalKeys = redisTemplate.keys("global:*");
+
+        if (userKeys != null && !userKeys.isEmpty()) {
+            redisTemplate.delete(userKeys);
+            log.info("사용자 키 정리 완료: {}개", userKeys.size());
+        }
+
+        if (globalKeys != null && !globalKeys.isEmpty()) {
+            redisTemplate.delete(globalKeys);
+            log.info("전역 키 정리 완료: {}개", globalKeys.size());
+        }
+
+        log.info("=== Redis 테스트 데이터 정리 완료 ===\n");
+    }
+
+    @Nested
+    @DisplayName("실제 Redis 기본 연동 테스트")
+    class BasicRedisOperationTest {
+
+        @Test
+        @DisplayName("실제 Redis에 토큰 초기화가 정상 작동한다")
+        void success_initializeTokensInRealRedis() {
+            log.info("=== 테스트 시작: 실제 Redis 토큰 초기화 ===");
+
+            // when
+            usageTokenService.initializeUserTokens(testMember.getMemberId());
+            log.info("토큰 초기화 실행 완료");
+
+            // then
+            String tokenKey = UsageType.getTokenKey(testMember.getMemberId());
+            Integer storedTokens = (Integer) redisTemplate.opsForValue().get(tokenKey);
+
+            assertThat(storedTokens).isNotNull();
+            assertThat(storedTokens).isEqualTo(UsageType.MAX_TOKENS);
+            log.info("✅ Redis 저장 확인: key={}, value={}", tokenKey, storedTokens);
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("실제 Redis에서 토큰 소모가 정상 작동한다")
+        void success_consumeTokensInRealRedis() {
+            log.info("=== 테스트 시작: 실제 Redis 토큰 소모 ===");
+
+            // given
+            usageTokenService.initializeUserTokens(testMember.getMemberId());
+            String tokenKey = UsageType.getTokenKey(testMember.getMemberId());
+            log.info("초기 토큰 설정 완료: {}개", UsageType.MAX_TOKENS);
+
+            // when
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.ESSAY_REVIEW);
+            log.info("토큰 소모 실행: ESSAY_REVIEW (5토큰)");
+
+            // then
+            Integer remainingTokens = (Integer) redisTemplate.opsForValue().get(tokenKey);
+            assertThat(remainingTokens).isEqualTo(35); // 40 - 5 = 35
+            log.info("✅ 토큰 소모 확인: 40 -> 35 (5토큰 차감)");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("실제 Redis에서 토큰 조회가 정상 작동한다")
+        void success_getTokenUsageFromRealRedis() {
+            log.info("=== 테스트 시작: 실제 Redis 토큰 조회 ===");
+
+            // given
+            usageTokenService.initializeUserTokens(testMember.getMemberId());
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.INTERVIEW_AUTO); // 3토큰 소모
+            log.info("토큰 초기화 및 소모 완료: 40 - 3 = 37");
+
+            // when
+            TokenUsageInfo result = usageTokenService.getTokenUsage(TEST_EMAIL);
+
+            // then
+            assertThat(result.remainingTokens()).isEqualTo(37);
+            assertThat(result.maxTokens()).isEqualTo(40);
+            assertThat(result.refillAmount()).isEqualTo(10);
+            log.info("✅ 조회 결과 확인: remainingTokens={}, maxTokens={}, refillAmount={}",
+                    result.remainingTokens(), result.maxTokens(), result.refillAmount());
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("실제 Redis 동시성 테스트")
+    class ConcurrencyTest {
+
+        @Test
+        @DisplayName("멀티스레드 환경에서 토큰 소모가 정확히 처리된다")
+        void success_concurrentTokenConsumption() throws InterruptedException {
+            log.info("=== 테스트 시작: 멀티스레드 토큰 소모 ===");
+
+            // given
+            usageTokenService.initializeUserTokens(testMember.getMemberId());
+            int threadCount = 20;
+            UsageType usageType = UsageType.INTERVIEW_CUSTOM; // 1토큰씩 소모
+
+            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            log.info("동시성 테스트 설정: {}개 스레드, {}토큰씩 소모", threadCount, usageType.getCost());
+
+            // when
+            for (int i = 0; i < threadCount; i++) {
+                final int threadNum = i;
+                executorService.submit(() -> {
+                    try {
+                        usageTokenService.tryConsumeTokens(testMember.getMemberId(), usageType);
+                        successCount.incrementAndGet();
+                        log.debug("스레드 {} 성공", threadNum);
+                    } catch (UsageLimitExceededException e) {
+                        failCount.incrementAndGet();
+                        log.debug("스레드 {} 실패: 토큰 부족", threadNum);
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await();
+            executorService.shutdown();
+
+            // then
+            String tokenKey = UsageType.getTokenKey(testMember.getMemberId());
+            Integer finalTokens = (Integer) redisTemplate.opsForValue().get(tokenKey);
+            int expectedFinalTokens = UsageType.MAX_TOKENS - (successCount.get() * usageType.getCost());
+
+            assertThat(finalTokens).isEqualTo(expectedFinalTokens);
+            assertThat(successCount.get() + failCount.get()).isEqualTo(threadCount);
+
+            log.info("✅ 동시성 테스트 결과:");
+            log.info("  - 성공한 스레드: {}개", successCount.get());
+            log.info("  - 실패한 스레드: {}개", failCount.get());
+            log.info("  - 최종 토큰: {}개 (예상: {}개)", finalTokens, expectedFinalTokens);
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("동시에 여러 사용자가 토큰을 사용해도 격리된다")
+        void success_multiUserConcurrency() throws Exception {
+            log.info("=== 테스트 시작: 다중 사용자 동시 토큰 사용 ===");
+
+            // given
+            Member user2 = new Member("google-test-2", "test2@example.com", "사용자2", "profile2.jpg");
+            user2 = memberRepository.save(user2);
+
+            usageTokenService.initializeUserTokens(testMember.getMemberId());
+            usageTokenService.initializeUserTokens(user2.getMemberId());
+            log.info("2명 사용자 토큰 초기화 완료");
+
+            // when
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.ESSAY_REVIEW); // 5토큰
+            usageTokenService.tryConsumeTokens(user2.getMemberId(), UsageType.INTERVIEW_AUTO); // 3토큰
+
+            // then
+            String tokenKey1 = UsageType.getTokenKey(testMember.getMemberId());
+            String tokenKey2 = UsageType.getTokenKey(user2.getMemberId());
+
+            Integer user1Tokens = (Integer) redisTemplate.opsForValue().get(tokenKey1);
+            Integer user2Tokens = (Integer) redisTemplate.opsForValue().get(tokenKey2);
+
+            assertThat(user1Tokens).isEqualTo(35); // 40 - 5
+            assertThat(user2Tokens).isEqualTo(37); // 40 - 3
+
+            log.info("✅ 사용자별 독립적 토큰 관리 확인:");
+            log.info("  - 사용자1: {}토큰 (40-5)", user1Tokens);
+            log.info("  - 사용자2: {}토큰 (40-3)", user2Tokens);
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("실제 Redis 전체 사용자 충전 테스트")
+    class RefillAllUsersTest {
+
+        @Test
+        @DisplayName("실제 Redis에서 전체 사용자 토큰 충전이 정상 작동한다")
+        void success_refillAllUsersInRealRedis() throws Exception {
+            log.info("=== 테스트 시작: 실제 Redis 전체 사용자 충전 ===");
+
+            // given
+            Member user2 = new Member("google-refill-test", "refill-test@example.com", "충전테스트", "profile.jpg");
+            user2 = memberRepository.save(user2);
+
+            // 초기화 후 일부 소모
+            usageTokenService.initializeUserTokens(testMember.getMemberId());
+            usageTokenService.initializeUserTokens(user2.getMemberId());
+
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.INTERVIEW_AUTO); // 3토큰 소모 -> 37
+            usageTokenService.tryConsumeTokens(user2.getMemberId(), UsageType.ESSAY_REVIEW); // 5토큰 소모 -> 35
+
+            log.info("초기 설정 완료: user1=37토큰, user2=35토큰");
+
+            // when
+            usageTokenService.refillAllUsersTokens();
+            log.info("전체 사용자 토큰 충전 실행");
+
+            // then
+            String tokenKey1 = UsageType.getTokenKey(testMember.getMemberId());
+            String tokenKey2 = UsageType.getTokenKey(user2.getMemberId());
+
+            Integer user1FinalTokens = (Integer) redisTemplate.opsForValue().get(tokenKey1);
+            Integer user2FinalTokens = (Integer) redisTemplate.opsForValue().get(tokenKey2);
+
+            assertThat(user1FinalTokens).isEqualTo(40); // 37 + 10 = 47이지만 최대 40
+            assertThat(user2FinalTokens).isEqualTo(40); // 35 + 10 = 45이지만 최대 40
+
+            log.info("✅ 전체 충전 결과 확인:");
+            log.info("  - 사용자1: 37 + 10 = 47 -> 40 (최대값 제한)");
+            log.info("  - 사용자2: 35 + 10 = 45 -> 40 (최대값 제한)");
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("실제 Redis 경계값 테스트")
+    class EdgeCaseTest {
+
+        @Test
+        @DisplayName("토큰이 0개일 때 추가 소모 시도 시 예외 발생")
+        void throwException_whenZeroTokens() {
+            log.info("=== 테스트 시작: 0토큰 상태에서 소모 시도 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(testMember.getMemberId());
+            redisTemplate.opsForValue().set(tokenKey, 0); // 직접 0으로 설정
+            log.info("토큰을 0개로 설정");
+
+            // when & then
+            assertThatThrownBy(() ->
+                    usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.INTERVIEW_CUSTOM))
+                    .isInstanceOf(UsageLimitExceededException.class);
+
+            // 토큰이 차감되지 않았는지 확인
+            Integer remainingTokens = (Integer) redisTemplate.opsForValue().get(tokenKey);
+            assertThat(remainingTokens).isEqualTo(0);
+
+            log.info("✅ 0토큰 상태에서 소모 시도 -> 예외 발생, 토큰 변화 없음");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("정확히 필요한 토큰만 있을 때 소모 성공")
+        void success_whenExactTokensAvailable() {
+            log.info("=== 테스트 시작: 정확한 토큰량 소모 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(testMember.getMemberId());
+            UsageType usageType = UsageType.ESSAY_REVIEW; // 5토큰 필요
+            redisTemplate.opsForValue().set(tokenKey, usageType.getCost()); // 정확히 5토큰 설정
+            log.info("토큰을 정확히 {}개로 설정", usageType.getCost());
+
+            // when
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), usageType);
+            log.info("토큰 소모 실행");
+
+            // then
+            Integer remainingTokens = (Integer) redisTemplate.opsForValue().get(tokenKey);
+            assertThat(remainingTokens).isEqualTo(0);
+
+            log.info("✅ 정확한 토큰 소모 성공: {} -> 0", usageType.getCost());
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("연속 시나리오 테스트")
+    class SequentialScenarioTest {
+
+        @Test
+        @DisplayName("실제 사용자 여정: 가입 -> 사용 -> 충전 -> 다시 사용")
+        void success_realUserJourney() {
+            log.info("=== 테스트 시작: 실제 사용자 여정 시뮬레이션 ===");
+
+            // 1. 신규 가입 (토큰 초기화)
+            usageTokenService.initializeUserTokens(testMember.getMemberId());
+            TokenUsageInfo step1 = usageTokenService.getTokenUsage(TEST_EMAIL);
+            assertThat(step1.remainingTokens()).isEqualTo(40);
+            log.info("1단계 - 신규 가입: {}토큰 초기화", step1.remainingTokens());
+
+            // 2. 여러 기능 사용
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.ESSAY_REVIEW); // 5토큰
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.INTERVIEW_AUTO); // 3토큰
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.INTERVIEW_CUSTOM); // 1토큰
+
+            TokenUsageInfo step2 = usageTokenService.getTokenUsage(TEST_EMAIL);
+            assertThat(step2.remainingTokens()).isEqualTo(31); // 40 - 5 - 3 - 1
+            log.info("2단계 - 기능 사용: 40 -> {}토큰 (9토큰 소모)", step2.remainingTokens());
+
+            // 3. 토큰 충전
+            usageTokenService.refillAllUsersTokens();
+            TokenUsageInfo step3 = usageTokenService.getTokenUsage(TEST_EMAIL);
+            assertThat(step3.remainingTokens()).isEqualTo(40); // 31 + 10 = 41이지만 최대 40
+            log.info("3단계 - 토큰 충전: 31 + 10 = 41 -> {}토큰 (최대값 제한)", step3.remainingTokens());
+
+            // 4. 다시 사용
+            usageTokenService.tryConsumeTokens(testMember.getMemberId(), UsageType.ESSAY_REVIEW); // 5토큰
+            TokenUsageInfo step4 = usageTokenService.getTokenUsage(TEST_EMAIL);
+            assertThat(step4.remainingTokens()).isEqualTo(35);
+            log.info("4단계 - 추가 사용: 40 -> {}토큰 (5토큰 소모)", step4.remainingTokens());
+
+            log.info("✅ 전체 사용자 여정 시뮬레이션 성공");
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+}

--- a/CVMento/src/test/java/com/cvmento/global/usage/service/UsageTokenServiceTest.java
+++ b/CVMento/src/test/java/com/cvmento/global/usage/service/UsageTokenServiceTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.*;
  * 3. 토큰 사용량 조회 - 이메일 기반 Member 조회 후 토큰 정보 반환
  * 4. 토큰 초기화 - 사용자별 최대값 설정
  * 5. 전체 사용자 충전 - 배치 충전 로직, 최대값 제한
- * 6. 다양한 UsageType별 소모량 - ESSAY_REVIEW(5), INTERVIEW_AUTO(3), INTERVIEW_CUSTOM(1)
+ * 6. 다양한 UsageType별 소모량 - COVERLETTER_REVIEW(5), INTERVIEW_AUTO(3), INTERVIEW_CUSTOM(1)
  * 7. 예외 상황 - 토큰 부족 시 UsageLimitExceededException, Redis 연결 실패 시 예외 전파
  *
  * 특징:
@@ -101,7 +101,7 @@ class UsageTokenServiceTest {
             // when & then
             log.info("메서드 실행: tryConsumeTokens");
             assertThatNoException()
-                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW));
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.COVERLETTER_REVIEW));
 
             verify(valueOperations).decrement(tokenKey, 5);
             log.info("✅ 토큰 차감 확인: decrement({}, 5) 호출됨", tokenKey);
@@ -121,7 +121,7 @@ class UsageTokenServiceTest {
             // when & then
             log.info("메서드 실행: tryConsumeTokens (예외 예상)");
             assertThatThrownBy(() ->
-                    usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW))
+                    usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.COVERLETTER_REVIEW))
                     .isInstanceOf(UsageLimitExceededException.class);
 
             verify(valueOperations, never()).decrement(any(), anyInt());
@@ -144,7 +144,7 @@ class UsageTokenServiceTest {
             // when & then
             log.info("메서드 실행: tryConsumeTokens (자동 초기화 예상)");
             assertThatNoException()
-                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW));
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.COVERLETTER_REVIEW));
 
             verify(valueOperations).set(tokenKey, UsageType.MAX_TOKENS); // 초기화 확인
             verify(valueOperations).decrement(tokenKey, 5); // 소모 확인
@@ -167,7 +167,7 @@ class UsageTokenServiceTest {
             // when & then
             log.info("메서드 실행: tryConsumeTokens");
             assertThatNoException()
-                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW));
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.COVERLETTER_REVIEW));
 
             verify(valueOperations).decrement(tokenKey, 5);
             log.info("✅ 정확한 토큰 소모 확인: 5토큰 -> 0토큰");
@@ -320,19 +320,19 @@ class UsageTokenServiceTest {
 
         @Test
         @DisplayName("자소서 첨삭(5토큰) 소모 테스트")
-        void consumeTokens_essayReview() {
+        void consumeTokens_coverLetterReview() {
             log.info("=== 테스트 시작: 자소서 첨삭(5토큰) 소모 ===");
 
             // given
             String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
             when(valueOperations.get(tokenKey)).thenReturn(10);
             when(valueOperations.decrement(tokenKey, 5)).thenReturn(5L);
-            log.info("Mock 설정: ESSAY_REVIEW, 현재 토큰=10, 소모=5");
+            log.info("Mock 설정: COVERLETTER_REVIEW, 현재 토큰=10, 소모=5");
 
             // when & then
-            log.info("메서드 실행: tryConsumeTokens(ESSAY_REVIEW)");
+            log.info("메서드 실행: tryConsumeTokens(COVERLETTER_REVIEW)");
             assertThatNoException()
-                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW));
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.COVERLETTER_REVIEW));
 
             verify(valueOperations).decrement(tokenKey, 5);
             log.info("✅ 자소서 첨삭 토큰 소모 확인: 5토큰 차감");
@@ -399,7 +399,7 @@ class UsageTokenServiceTest {
             // when & then
             log.info("메서드 실행: tryConsumeTokens (예외 정보 검증)");
             assertThatThrownBy(() ->
-                    usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW)) // 5토큰 필요
+                    usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.COVERLETTER_REVIEW)) // 5토큰 필요
                     .isInstanceOf(UsageLimitExceededException.class)
                     .satisfies(ex -> {
                         log.info("발생한 예외: {}, 메시지: {}",
@@ -422,7 +422,7 @@ class UsageTokenServiceTest {
             // when & then
             log.info("메서드 실행: tryConsumeTokens (Redis 예외 전파 검증)");
             assertThatThrownBy(() ->
-                    usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW))
+                    usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.COVERLETTER_REVIEW))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Redis connection failed");
             log.info("✅ Redis 연결 실패 예외 전파 확인");

--- a/CVMento/src/test/java/com/cvmento/global/usage/service/UsageTokenServiceTest.java
+++ b/CVMento/src/test/java/com/cvmento/global/usage/service/UsageTokenServiceTest.java
@@ -1,0 +1,440 @@
+package com.cvmento.global.usage.service;
+
+import com.cvmento.domain.member.entity.Member;
+import com.cvmento.domain.member.repository.MemberRepository;
+import com.cvmento.global.usage.dto.TokenUsageInfo;
+import com.cvmento.global.usage.enums.UsageType;
+import com.cvmento.global.exception.customException.UsageLimitExceededException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * UsageTokenService 단위 테스트
+ *
+ * 목적: 비즈니스 로직의 정확성 검증
+ * 방식: Mock 기반, 외부 의존성 제거
+ *
+ * 검증 내용:
+ * 1. 토큰 소모 로직 - 충분한 토큰, 부족한 토큰, 정확한 토큰량 시나리오
+ * 2. 첫 사용자 자동 초기화 - null 상태에서 MAX_TOKENS로 설정
+ * 3. 토큰 사용량 조회 - 이메일 기반 Member 조회 후 토큰 정보 반환
+ * 4. 토큰 초기화 - 사용자별 최대값 설정
+ * 5. 전체 사용자 충전 - 배치 충전 로직, 최대값 제한
+ * 6. 다양한 UsageType별 소모량 - ESSAY_REVIEW(5), INTERVIEW_AUTO(3), INTERVIEW_CUSTOM(1)
+ * 7. 예외 상황 - 토큰 부족 시 UsageLimitExceededException, Redis 연결 실패 시 예외 전파
+ *
+ * 특징:
+ * - RedisTemplate, MemberRepository 모두 Mock 처리
+ * - 빠른 실행 속도 (외부 의존성 없음)
+ * - 비즈니스 로직 중심 검증
+ * - verify()로 메서드 호출 여부 정확히 확인
+ */
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+class UsageTokenServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private UsageTokenService usageTokenService;
+
+    private Member testMember;
+    private final Long TEST_MEMBER_ID = 1L;
+    private final String TEST_EMAIL = "test@example.com";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        log.info("=== 테스트 데이터 설정 시작 ===");
+
+        testMember = new Member("google123", TEST_EMAIL, "테스트사용자", "profile.jpg");
+        // 리플렉션으로 memberId 설정
+        setField(testMember, "memberId", TEST_MEMBER_ID);
+        log.info("테스트 Member 생성: email={}, name={}, memberId={}", TEST_EMAIL, "테스트사용자", TEST_MEMBER_ID);
+
+        // RedisTemplate의 opsForValue()가 valueOperations를 반환하도록 설정 (lenient로 설정)
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        log.info("Mock 설정 완료: RedisTemplate -> ValueOperations");
+
+        log.info("=== 테스트 데이터 설정 완료 ===\n");
+    }
+
+    @Nested
+    @DisplayName("토큰 소모 테스트")
+    class TryConsumeTokensTest {
+
+        @Test
+        @DisplayName("충분한 토큰이 있을 때 정상적으로 소모된다")
+        void success_whenSufficientTokens() {
+            log.info("=== 테스트 시작: 충분한 토큰 소모 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(15); // 현재 15토큰
+            when(valueOperations.decrement(tokenKey, 5)).thenReturn(10L); // 5토큰 소모 후 10토큰
+            log.info("Mock 설정: 현재 토큰=15, 소모 토큰=5, 결과=10");
+
+            // when & then
+            log.info("메서드 실행: tryConsumeTokens");
+            assertThatNoException()
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW));
+
+            verify(valueOperations).decrement(tokenKey, 5);
+            log.info("✅ 토큰 차감 확인: decrement({}, 5) 호출됨", tokenKey);
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("토큰이 부족할 때 예외가 발생한다")
+        void throwException_whenInsufficientTokens() {
+            log.info("=== 테스트 시작: 토큰 부족 예외 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(3); // 현재 3토큰
+            log.info("Mock 설정: 현재 토큰=3, 필요 토큰=5 -> 부족");
+
+            // when & then
+            log.info("메서드 실행: tryConsumeTokens (예외 예상)");
+            assertThatThrownBy(() ->
+                    usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW))
+                    .isInstanceOf(UsageLimitExceededException.class);
+
+            verify(valueOperations, never()).decrement(any(), anyInt());
+            log.info("✅ 예외 발생 확인: UsageLimitExceededException");
+            log.info("✅ 토큰 차감 안됨 확인: decrement 호출되지 않음");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("첫 사용자(토큰이 null)일 때 자동 초기화 후 소모한다")
+        void autoInitialize_whenFirstTimeUser() {
+            log.info("=== 테스트 시작: 첫 사용자 자동 초기화 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(null); // 첫 사용자
+            when(valueOperations.decrement(tokenKey, 5)).thenReturn(35L); // 초기화(40) 후 소모(5) -> 35
+            log.info("Mock 설정: 첫 사용자(null) -> 자동 초기화 -> 토큰 소모");
+
+            // when & then
+            log.info("메서드 실행: tryConsumeTokens (자동 초기화 예상)");
+            assertThatNoException()
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW));
+
+            verify(valueOperations).set(tokenKey, UsageType.MAX_TOKENS); // 초기화 확인
+            verify(valueOperations).decrement(tokenKey, 5); // 소모 확인
+            log.info("✅ 자동 초기화 확인: set({}, {}) 호출됨", tokenKey, UsageType.MAX_TOKENS);
+            log.info("✅ 토큰 소모 확인: decrement({}, 5) 호출됨", tokenKey);
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("정확히 필요한 토큰만 있을 때 성공한다")
+        void success_whenExactTokensNeeded() {
+            log.info("=== 테스트 시작: 정확한 토큰량 소모 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(5); // 정확히 5토큰
+            when(valueOperations.decrement(tokenKey, 5)).thenReturn(0L); // 소모 후 0토큰
+            log.info("Mock 설정: 현재 토큰=5, 필요 토큰=5 -> 정확히 일치");
+
+            // when & then
+            log.info("메서드 실행: tryConsumeTokens");
+            assertThatNoException()
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW));
+
+            verify(valueOperations).decrement(tokenKey, 5);
+            log.info("✅ 정확한 토큰 소모 확인: 5토큰 -> 0토큰");
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 사용량 조회 테스트")
+    class GetTokenUsageTest {
+
+        @Test
+        @DisplayName("정상적으로 토큰 사용량을 조회한다")
+        void success_getTokenUsage() {
+            log.info("=== 테스트 시작: 토큰 사용량 조회 ===");
+
+            // given
+            when(memberRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(testMember));
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(25);
+            log.info("Mock 설정: 사용자 조회 성공, 현재 토큰=25");
+
+            // when
+            log.info("메서드 실행: getTokenUsage");
+            TokenUsageInfo result = usageTokenService.getTokenUsage(TEST_EMAIL);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.remainingTokens()).isEqualTo(25);
+            assertThat(result.maxTokens()).isEqualTo(UsageType.MAX_TOKENS);
+            assertThat(result.refillAmount()).isEqualTo(UsageType.REFILL_AMOUNT);
+            assertThat(result.nextRefillTime()).isNotNull();
+            log.info("✅ 조회 결과 확인: remainingTokens={}, maxTokens={}, refillAmount={}",
+                    result.remainingTokens(), result.maxTokens(), result.refillAmount());
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("첫 사용자(토큰이 null)일 때 자동 초기화 후 조회한다")
+        void autoInitialize_whenFirstTimeUserQuery() {
+            log.info("=== 테스트 시작: 첫 사용자 조회 시 자동 초기화 ===");
+
+            // given
+            when(memberRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(testMember));
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(null); // 첫 사용자
+            log.info("Mock 설정: 사용자 조회 성공, 첫 사용자(토큰=null)");
+
+            // when
+            log.info("메서드 실행: getTokenUsage (자동 초기화 예상)");
+            TokenUsageInfo result = usageTokenService.getTokenUsage(TEST_EMAIL);
+
+            // then
+            assertThat(result.remainingTokens()).isEqualTo(UsageType.MAX_TOKENS);
+            verify(valueOperations).set(tokenKey, UsageType.MAX_TOKENS); // 초기화 확인
+            log.info("✅ 자동 초기화 확인: set({}, {}) 호출됨", tokenKey, UsageType.MAX_TOKENS);
+            log.info("✅ 조회 결과: remainingTokens={}", result.remainingTokens());
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 초기화 테스트")
+    class InitializeUserTokensTest {
+
+        @Test
+        @DisplayName("사용자 토큰을 최대값으로 초기화한다")
+        void success_initializeUserTokens() {
+            log.info("=== 테스트 시작: 사용자 토큰 초기화 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            log.info("초기화 대상: memberId={}, tokenKey={}", TEST_MEMBER_ID, tokenKey);
+
+            // when
+            log.info("메서드 실행: initializeUserTokens");
+            usageTokenService.initializeUserTokens(TEST_MEMBER_ID);
+
+            // then
+            verify(valueOperations).set(tokenKey, UsageType.MAX_TOKENS);
+            log.info("✅ 초기화 확인: set({}, {}) 호출됨", tokenKey, UsageType.MAX_TOKENS);
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 사용자 토큰 충전 테스트")
+    class RefillAllUsersTokensTest {
+
+        @Test
+        @DisplayName("모든 사용자의 토큰을 충전한다")
+        void success_refillAllUsersTokens() {
+            log.info("=== 테스트 시작: 전체 사용자 토큰 충전 ===");
+
+            // given
+            Set<String> tokenKeys = Set.of(
+                    "user:1:tokens",
+                    "user:2:tokens",
+                    "user:3:tokens"
+            );
+            when(redisTemplate.keys("user:*:tokens")).thenReturn(tokenKeys);
+
+            // 각 사용자의 현재 토큰 설정 (변경된 REFILL_AMOUNT=10 적용)
+            when(valueOperations.get("user:1:tokens")).thenReturn(10); // 10 + 10 = 20
+            when(valueOperations.get("user:2:tokens")).thenReturn(25); // 25 + 10 = 35
+            when(valueOperations.get("user:3:tokens")).thenReturn(40); // 이미 최대
+            log.info("Mock 설정: 대상 사용자 3명 (토큰: 10, 25, 40), 충전량: 10");
+
+            // when
+            log.info("메서드 실행: refillAllUsersTokens");
+            usageTokenService.refillAllUsersTokens();
+
+            // then
+            verify(valueOperations).set("user:1:tokens", 20); // 10 + 10 = 20
+            verify(valueOperations).set("user:2:tokens", 35); // 25 + 10 = 35
+            verify(valueOperations, never()).set(eq("user:3:tokens"), any()); // 이미 최대이므로 충전 안함
+
+            // 전역 마지막 충전 시간 업데이트 확인
+            verify(valueOperations).set(eq(UsageType.getGlobalLastRefillKey()), anyString());
+            log.info("✅ 충전 결과: user1(10->20), user2(25->35), user3(40, 충전안함)");
+            log.info("✅ 전역 충전 시간 업데이트 확인");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("토큰 충전 시 최대값을 초과하지 않는다")
+        void notExceedMaxTokens_whenRefill() {
+            log.info("=== 테스트 시작: 토큰 충전 최대값 제한 ===");
+
+            // given
+            Set<String> tokenKeys = Set.of("user:1:tokens");
+            when(redisTemplate.keys("user:*:tokens")).thenReturn(tokenKeys);
+            when(valueOperations.get("user:1:tokens")).thenReturn(35); // 35 + 10 = 45이지만 최대 40
+            log.info("Mock 설정: 현재 토큰=35, 충전량=10, 예상 결과=40(최대값 제한)");
+
+            // when
+            log.info("메서드 실행: refillAllUsersTokens");
+            usageTokenService.refillAllUsersTokens();
+
+            // then
+            verify(valueOperations).set("user:1:tokens", 40); // 최대 40으로 제한
+            log.info("✅ 최대값 제한 확인: 35 + 10 = 45 -> 40(최대값)");
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("다양한 토큰 소모량 테스트")
+    class DifferentUsageTypesTest {
+
+        @Test
+        @DisplayName("자소서 첨삭(5토큰) 소모 테스트")
+        void consumeTokens_essayReview() {
+            log.info("=== 테스트 시작: 자소서 첨삭(5토큰) 소모 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(10);
+            when(valueOperations.decrement(tokenKey, 5)).thenReturn(5L);
+            log.info("Mock 설정: ESSAY_REVIEW, 현재 토큰=10, 소모=5");
+
+            // when & then
+            log.info("메서드 실행: tryConsumeTokens(ESSAY_REVIEW)");
+            assertThatNoException()
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW));
+
+            verify(valueOperations).decrement(tokenKey, 5);
+            log.info("✅ 자소서 첨삭 토큰 소모 확인: 5토큰 차감");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("자소서 기반 면접(3토큰) 소모 테스트")
+        void consumeTokens_interviewAuto() {
+            log.info("=== 테스트 시작: 자소서 기반 면접(3토큰) 소모 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(10);
+            when(valueOperations.decrement(tokenKey, 3)).thenReturn(7L); // 변경: 3토큰 소모
+            log.info("Mock 설정: INTERVIEW_AUTO, 현재 토큰=10, 소모=3");
+
+            // when & then
+            log.info("메서드 실행: tryConsumeTokens(INTERVIEW_AUTO)");
+            assertThatNoException()
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.INTERVIEW_AUTO));
+
+            verify(valueOperations).decrement(tokenKey, 3); // 변경: 3토큰 검증
+            log.info("✅ 자소서 기반 면접 토큰 소모 확인: 3토큰 차감");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("커스텀 면접(1토큰) 소모 테스트")
+        void consumeTokens_interviewCustom() {
+            log.info("=== 테스트 시작: 커스텀 면접(1토큰) 소모 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(5);
+            when(valueOperations.decrement(tokenKey, 1)).thenReturn(4L); // 변경: 1토큰 소모
+            log.info("Mock 설정: INTERVIEW_CUSTOM, 현재 토큰=5, 소모=1");
+
+            // when & then
+            log.info("메서드 실행: tryConsumeTokens(INTERVIEW_CUSTOM)");
+            assertThatNoException()
+                    .isThrownBy(() -> usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.INTERVIEW_CUSTOM));
+
+            verify(valueOperations).decrement(tokenKey, 1); // 변경: 1토큰 검증
+            log.info("✅ 커스텀 면접 토큰 소모 확인: 1토큰 차감");
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 상황 테스트")
+    class ExceptionScenariosTest {
+
+        @Test
+        @DisplayName("토큰 부족 시 예외에 정확한 정보가 포함된다")
+        void exceptionContainsCorrectInfo_whenInsufficientTokens() {
+            log.info("=== 테스트 시작: 토큰 부족 예외 정보 검증 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenReturn(3); // 3토큰 보유
+            log.info("Mock 설정: 현재 토큰=3, 필요 토큰=5 -> 부족");
+
+            // when & then
+            log.info("메서드 실행: tryConsumeTokens (예외 정보 검증)");
+            assertThatThrownBy(() ->
+                    usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW)) // 5토큰 필요
+                    .isInstanceOf(UsageLimitExceededException.class)
+                    .satisfies(ex -> {
+                        log.info("발생한 예외: {}, 메시지: {}",
+                                ex.getClass().getSimpleName(), ex.getMessage());
+                    });
+            log.info("✅ UsageLimitExceededException 발생 및 정보 포함 확인");
+            log.info("=== 테스트 완료 ===\n");
+        }
+
+        @Test
+        @DisplayName("Redis 연결 실패 시 예외가 전파된다")
+        void propagateException_whenRedisConnectionFails() {
+            log.info("=== 테스트 시작: Redis 연결 실패 예외 전파 ===");
+
+            // given
+            String tokenKey = UsageType.getTokenKey(TEST_MEMBER_ID);
+            when(valueOperations.get(tokenKey)).thenThrow(new RuntimeException("Redis connection failed"));
+            log.info("Mock 설정: Redis 연결 실패 예외 발생");
+
+            // when & then
+            log.info("메서드 실행: tryConsumeTokens (Redis 예외 전파 검증)");
+            assertThatThrownBy(() ->
+                    usageTokenService.tryConsumeTokens(TEST_MEMBER_ID, UsageType.ESSAY_REVIEW))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Redis connection failed");
+            log.info("✅ Redis 연결 실패 예외 전파 확인");
+            log.info("=== 테스트 완료 ===\n");
+        }
+    }
+
+    // 리플렉션 헬퍼 메서드 추가
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+        log.debug("리플렉션으로 필드 설정: {}.{} = {}", target.getClass().getSimpleName(), fieldName, value);
+    }
+}


### PR DESCRIPTION
- redis 활용해서 유저의 사용 횟수를 토큰으로 관리
- 서버가 실행되면 ACTIVE한 유저 기준으로 처음에 40개 주고, 특정 요청에 따라 다른 수의 토큰이 빠진다
- 자소서첨삭 5개, 모의면접 자동생성 3개, 커스텀 1개
- 사용 시점과 무관하게, 스케쥴링에 의해서 2시간 마다 정각에 토큰이 5개씩 충전된다.
- 인터셉터로 관리해서, 시큐리티 필터 이후에 컨트롤러 전에 동작한다.
- 커스텀 어노테이션으로 만들어서 컨트롤러 상단에 추가하는 구조다
- 로그인 쪽에, 신규가입이라면 토큰이 발급되게 추가하였다.
- 서버 시간대를 서울로 맞춰뒀다.
- 유저 사용제한 서비스의 단위테스트와 redis를 붙였을때의 통합테스트가 추가되었다.
+ 추가적으로, 이전 인터뷰 관련 서비스 코드에서 멤버 정보와 자소서id를 통해서 자소서를 가져오는 로직이 수정되면서, 테스트코드에 반영이 안되서 빌드 오류 발생한 부분도 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 토큰 기반 사용량 관리 시스템 추가(소비·조회·초기화·충전)
  - 내 토큰 조회 API 및 사용량 포함 응답 보조 기능 제공
- Improvements
  - AI 기능(자소서 첨삭, 모의 면접)에 토큰 검증 적용 및 2시간마다 자동 충전 스케줄러 운영
  - 사용 한도 초과 시 429 응답에 상세 정보 포함
- Chores
  - 애플리케이션 시간대(Asia/Seoul) 통일 및 스케줄링 활성화
- Tests
  - 토큰 서비스 단위/통합 테스트 추가 및 면접 서비스 테스트 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->