### PR TITLE
Feature/cover letter : 자소서 수정/삭제

### DIFF
--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/controller/CoverLetterController.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/controller/CoverLetterController.java
@@ -1,6 +1,7 @@
 package com.cvmento.domain.coverLetter.controller;
 
 import com.cvmento.domain.coverLetter.dto.request.CoverLetterSaveRequest;
+import com.cvmento.domain.coverLetter.dto.request.CoverLetterUpdateRequest;
 import com.cvmento.domain.coverLetter.dto.response.CoverLetterDetailResponse;
 import com.cvmento.domain.coverLetter.dto.response.CoverLetterListResponse;
 import com.cvmento.domain.coverLetter.service.CoverLetterService;
@@ -205,4 +206,72 @@ public class CoverLetterController {
 
         return ResponseEntity.ok(CommonResponse.success("자소서 조회 성공", response));
     }
+
+    @Operation(
+            summary = "자소서 수정",
+            description = "기존 자소서를 수정합니다. 제목에 [수정본] 접두사가 자동으로 추가됩니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "수정할 자소서 정보",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = CoverLetterUpdateRequest.class),
+                            examples = @ExampleObject(
+                                    name = "자소서 수정 요청",
+                                    value = "{\n" +
+                                            "  \"title\": \"네이버 백엔드 개발자 지원\",\n" +
+                                            "  \"content\": \"저는 소프트웨어 개발에 대한 깊은 열정을 바탕으로 지속적으로 성장해온 개발자입니다. 특히 백엔드 개발 분야에서 Spring Boot와 JPA를 활용한 다양한 프로젝트를 통해 실무 경험을 쌓아왔습니다. 최근에는 성능 최적화와 코드 품질 향상에 특별한 관심을 가지고 있습니다.\",\n" +
+                                            "  \"jobField\": \"백엔드 개발자\",\n" +
+                                            "  \"experienceYears\": 2\n" +
+                                            "}"
+                            )
+                    )
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "자소서 수정 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = CommonResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "자소서 수정 성공 응답",
+                                            value = "{\n" +
+                                                    "  \"success\": true,\n" +
+                                                    "  \"message\": \"자소서가 수정되었습니다.\",\n" +
+                                                    "  \"data\": null\n" +
+                                                    "}"
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "자소서를 찾을 수 없음",
+                            content = @Content(
+                                    schema = @Schema(implementation = CommonResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청 데이터",
+                            content = @Content(
+                                    schema = @Schema(implementation = CommonResponse.class)
+                            )
+                    )
+            }
+    )
+    @PutMapping("/{coverLetterId}")
+    public ResponseEntity<CommonResponse<Void>> updateCoverLetter(
+            @Parameter(description = "수정할 자소서 ID") @PathVariable Long coverLetterId,
+            @Valid @RequestBody CoverLetterUpdateRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String userEmail = userDetails.getUsername();
+        coverLetterService.updateCoverLetter(coverLetterId, request, userEmail);
+
+        return ResponseEntity.ok(CommonResponse.success("자소서가 수정되었습니다.", null));
+    }
+
+
+    /**
+     * 자소서 삭제 API (소프트삭제) - 추후 구현 예정
+     */
 }

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/controller/CoverLetterController.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/controller/CoverLetterController.java
@@ -96,8 +96,8 @@ public class CoverLetterController {
             @Valid @RequestBody CoverLetterSaveRequest request,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        String userEmail = userDetails.getUsername();
-        coverLetterService.saveCoverLetter(request, userEmail);
+        String memberEmail = userDetails.getUsername();
+        coverLetterService.saveCoverLetter(request, memberEmail);
 
         String message = request.isAiImproved() ?
                 "AI 첨삭된 자소서가 저장되었습니다." :
@@ -105,106 +105,6 @@ public class CoverLetterController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.success(message, null));
-    }
-
-    @Operation(
-            summary = "자소서 목록 조회",
-            description = "사용자의 자소서 목록을 페이징으로 조회합니다. 최신 수정일 순으로 정렬됩니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "자소서 목록 조회 성공",
-                            content = @Content(
-                                    schema = @Schema(implementation = CommonResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "자소서 목록 조회 응답",
-                                            value = "{\n" +
-                                                    "  \"success\": true,\n" +
-                                                    "  \"message\": \"자소서 목록 조회 성공\",\n" +
-                                                    "  \"data\": {\n" +
-                                                    "    \"content\": [\n" +
-                                                    "      {\n" +
-                                                    "        \"coverLetterId\": 1,\n" +
-                                                    "        \"title\": \"[AI첨삭] 네이버 백엔드 개발자 지원\",\n" +
-                                                    "        \"content\": \"저는 백엔드 개발 분야에서 3년간의 실무 경험을 통해 확고한 기술적 역량을 구축해왔습니다...\",\n" +
-                                                    "        \"jobField\": \"백엔드 개발자\",\n" +
-                                                    "        \"experience\": \"3년\",\n" +
-                                                    "        \"createdAt\": \"2025-09-01T10:30:00\",\n" +
-                                                    "        \"updatedAt\": \"2025-09-01T10:35:00\"\n" +
-                                                    "      }\n" +
-                                                    "    ],\n" +
-                                                    "    \"pageable\": {\n" +
-                                                    "      \"pageNumber\": 0,\n" +
-                                                    "      \"pageSize\": 5\n" +
-                                                    "    },\n" +
-                                                    "    \"totalElements\": 15,\n" +
-                                                    "    \"totalPages\": 3\n" +
-                                                    "  }\n" +
-                                                    "}"
-                                    )
-                            )
-                    )
-            }
-    )
-    @GetMapping
-    public ResponseEntity<CommonResponse<Page<CoverLetterListResponse>>> getCoverLetters(
-            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "5") int size,
-            @Parameter(description = "뷰 타입 (thumbnail: 미리보기, 그외: 전체내용)") @RequestParam(required = false) String view,
-            @AuthenticationPrincipal UserDetails userDetails
-    ) {
-        String userEmail = userDetails.getUsername();
-        Pageable pageable = PageRequest.of(page, size);
-        Page<CoverLetterListResponse> response = coverLetterService.getCoverLetters(userEmail, pageable, view);
-
-        return ResponseEntity.ok(CommonResponse.success("자소서 목록 조회 성공", response));
-    }
-
-    @Operation(
-            summary = "자소서 상세 조회",
-            description = "특정 자소서의 상세 정보를 조회합니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "자소서 조회 성공",
-                            content = @Content(
-                                    schema = @Schema(implementation = CommonResponse.class),
-                                    examples = @ExampleObject(
-                                            name = "자소서 상세 조회 응답",
-                                            value = "{\n" +
-                                                    "  \"success\": true,\n" +
-                                                    "  \"message\": \"자소서 조회 성공\",\n" +
-                                                    "  \"data\": {\n" +
-                                                    "    \"coverLetterId\": 1,\n" +
-                                                    "    \"title\": \"[원본] 네이버 백엔드 개발자 지원\",\n" +
-                                                    "    \"content\": \"저는 소프트웨어 개발에 대한 열정을 바탕으로 다양한 프로젝트를 수행해왔습니다. 특히 백엔드 개발에 관심이 많아 Spring Boot와 JPA를 활용한 REST API 개발 경험이 있습니다. 대학교 재학 중 진행한 팀 프로젝트에서는 주도적으로 서버 아키텍처를 설계하고 구현했으며, 이를 통해 협업과 문제해결 능력을 기를 수 있었습니다.\",\n" +
-                                                    "    \"jobField\": \"백엔드 개발자\",\n" +
-                                                    "    \"experience\": \"1년\",\n" +
-                                                    "    \"createdAt\": \"2025-09-01T10:30:00\",\n" +
-                                                    "    \"updatedAt\": \"2025-09-01T10:30:00\"\n" +
-                                                    "  }\n" +
-                                                    "}"
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "자소서를 찾을 수 없음",
-                            content = @Content(
-                                    schema = @Schema(implementation = CommonResponse.class)
-                            )
-                    )
-            }
-    )
-    @GetMapping("/{coverLetterId}")
-    public ResponseEntity<CommonResponse<CoverLetterDetailResponse>> getCoverLetter(
-            @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
-            @AuthenticationPrincipal UserDetails userDetails
-    ) {
-        String userEmail = userDetails.getUsername();
-        CoverLetterDetailResponse response = coverLetterService.getCoverLetter(coverLetterId, userEmail);
-
-        return ResponseEntity.ok(CommonResponse.success("자소서 조회 성공", response));
     }
 
     @Operation(
@@ -264,14 +164,148 @@ public class CoverLetterController {
             @Valid @RequestBody CoverLetterUpdateRequest request,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        String userEmail = userDetails.getUsername();
-        coverLetterService.updateCoverLetter(coverLetterId, request, userEmail);
+        String memberEmail = userDetails.getUsername();
+        coverLetterService.updateCoverLetter(coverLetterId, request, memberEmail);
 
         return ResponseEntity.ok(CommonResponse.success("자소서가 수정되었습니다.", null));
     }
 
+    @Operation(
+            summary = "자소서 삭제 (소프트 삭제)",
+            description = "자소서를 삭제합니다. 실제로는 상태만 변경되어 복구가 가능합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "자소서 삭제 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = CommonResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "자소서 삭제 성공 응답",
+                                            value = "{\n" +
+                                                    "  \"success\": true,\n" +
+                                                    "  \"message\": \"자소서가 삭제되었습니다.\",\n" +
+                                                    "  \"data\": null\n" +
+                                                    "}"
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "자소서를 찾을 수 없음",
+                            content = @Content(
+                                    schema = @Schema(implementation = CommonResponse.class)
+                            )
+                    )
+            }
+    )
+    @DeleteMapping("/{coverLetterId}")
+    public ResponseEntity<CommonResponse<Void>> deleteCoverLetter(
+            @Parameter(description = "삭제할 자소서 ID") @PathVariable Long coverLetterId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String memberEmail = userDetails.getUsername();
+        coverLetterService.deleteCoverLetter(coverLetterId, memberEmail);
 
-    /**
-     * 자소서 삭제 API (소프트삭제) - 추후 구현 예정
-     */
+        return ResponseEntity.ok(CommonResponse.success("자소서가 삭제되었습니다.", null));
+    }
+
+    @Operation(
+            summary = "자소서 목록 조회",
+            description = "사용자의 자소서 목록을 페이징으로 조회합니다. 최신 수정일 순으로 정렬됩니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "자소서 목록 조회 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = CommonResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "자소서 목록 조회 응답",
+                                            value = "{\n" +
+                                                    "  \"success\": true,\n" +
+                                                    "  \"message\": \"자소서 목록 조회 성공\",\n" +
+                                                    "  \"data\": {\n" +
+                                                    "    \"content\": [\n" +
+                                                    "      {\n" +
+                                                    "        \"coverLetterId\": 1,\n" +
+                                                    "        \"title\": \"[AI첨삭] 네이버 백엔드 개발자 지원\",\n" +
+                                                    "        \"content\": \"저는 백엔드 개발 분야에서 3년간의 실무 경험을 통해 확고한 기술적 역량을 구축해왔습니다...\",\n" +
+                                                    "        \"jobField\": \"백엔드 개발자\",\n" +
+                                                    "        \"experience\": \"3년\",\n" +
+                                                    "        \"createdAt\": \"2025-09-01T10:30:00\",\n" +
+                                                    "        \"updatedAt\": \"2025-09-01T10:35:00\"\n" +
+                                                    "      }\n" +
+                                                    "    ],\n" +
+                                                    "    \"pageable\": {\n" +
+                                                    "      \"pageNumber\": 0,\n" +
+                                                    "      \"pageSize\": 5\n" +
+                                                    "    },\n" +
+                                                    "    \"totalElements\": 15,\n" +
+                                                    "    \"totalPages\": 3\n" +
+                                                    "  }\n" +
+                                                    "}"
+                                    )
+                            )
+                    )
+            }
+    )
+    @GetMapping
+    public ResponseEntity<CommonResponse<Page<CoverLetterListResponse>>> getCoverLetters(
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "5") int size,
+            @Parameter(description = "뷰 타입 (thumbnail: 미리보기, 그외: 전체내용)") @RequestParam(required = false) String view,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String memberEmail = userDetails.getUsername();
+        Pageable pageable = PageRequest.of(page, size);
+        Page<CoverLetterListResponse> response = coverLetterService.getCoverLetters(memberEmail, pageable, view);
+
+        return ResponseEntity.ok(CommonResponse.success("자소서 목록 조회 성공", response));
+    }
+
+    @Operation(
+            summary = "자소서 상세 조회",
+            description = "특정 자소서의 상세 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "자소서 조회 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = CommonResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "자소서 상세 조회 응답",
+                                            value = "{\n" +
+                                                    "  \"success\": true,\n" +
+                                                    "  \"message\": \"자소서 조회 성공\",\n" +
+                                                    "  \"data\": {\n" +
+                                                    "    \"coverLetterId\": 1,\n" +
+                                                    "    \"title\": \"[원본] 네이버 백엔드 개발자 지원\",\n" +
+                                                    "    \"content\": \"저는 소프트웨어 개발에 대한 열정을 바탕으로 다양한 프로젝트를 수행해왔습니다. 특히 백엔드 개발에 관심이 많아 Spring Boot와 JPA를 활용한 REST API 개발 경험이 있습니다. 대학교 재학 중 진행한 팀 프로젝트에서는 주도적으로 서버 아키텍처를 설계하고 구현했으며, 이를 통해 협업과 문제해결 능력을 기를 수 있었습니다.\",\n" +
+                                                    "    \"jobField\": \"백엔드 개발자\",\n" +
+                                                    "    \"experience\": \"1년\",\n" +
+                                                    "    \"createdAt\": \"2025-09-01T10:30:00\",\n" +
+                                                    "    \"updatedAt\": \"2025-09-01T10:30:00\"\n" +
+                                                    "  }\n" +
+                                                    "}"
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "자소서를 찾을 수 없음",
+                            content = @Content(
+                                    schema = @Schema(implementation = CommonResponse.class)
+                            )
+                    )
+            }
+    )
+    @GetMapping("/{coverLetterId}")
+    public ResponseEntity<CommonResponse<CoverLetterDetailResponse>> getCoverLetter(
+            @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String memberEmail = userDetails.getUsername();
+        CoverLetterDetailResponse response = coverLetterService.getCoverLetter(coverLetterId, memberEmail);
+
+        return ResponseEntity.ok(CommonResponse.success("자소서 조회 성공", response));
+    }
 }

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/dto/request/CoverLetterUpdateRequest.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/dto/request/CoverLetterUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.cvmento.domain.coverLetter.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "자소서 수정 요청 DTO")
+public record CoverLetterUpdateRequest(
+
+        @Schema(description = "자소서 제목", example = "네이버 백엔드 개발자 지원")
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 200, message = "제목은 200자 이내로 입력해주세요.")
+        String title,
+
+        @Schema(description = "자소서 내용", example = "저는 소프트웨어 개발에 대한 열정을 바탕으로...")
+        @NotBlank(message = "내용은 필수입니다.")
+        @Size(max = 10000, message = "내용은 10000자 이내로 입력해주세요.")
+        String content,
+
+        @Schema(description = "지원분야", example = "백엔드 개발자")
+        @Size(max = 100, message = "지원분야는 100자 이내로 입력해주세요.")
+        String jobField,
+
+        @Schema(description = "경력 년수 (0: 신입)", example = "1")
+        @Min(value = 0, message = "경력 년수는 0 이상이어야 합니다.")
+        @Max(value = 50, message = "경력 년수는 50 이하여야 합니다.")
+        Integer experienceYears
+) {
+}

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/entity/CoverLetter.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/entity/CoverLetter.java
@@ -63,4 +63,12 @@ public class CoverLetter extends BaseTimeEntity {
         }
         return experienceYears + "년";
     }
+
+    // 자소서 정보 업데이트 메서드
+    public void updateCoverLetter(String title, String content, String jobField, Integer experienceYears) {
+        this.title = title;
+        this.content = content;
+        this.jobField = jobField;
+        this.experienceYears = experienceYears;
+    }
 }

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/entity/CoverLetter.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/entity/CoverLetter.java
@@ -1,5 +1,6 @@
 package com.cvmento.domain.coverLetter.entity;
 
+import com.cvmento.domain.coverLetter.enums.CoverLetterStatus;
 import com.cvmento.domain.interview.entity.CoverLetterQna;
 import com.cvmento.domain.member.entity.Member;
 import com.cvmento.global.common.entity.BaseTimeEntity;
@@ -30,6 +31,10 @@ public class CoverLetter extends BaseTimeEntity {
 
     @Column(name = "experience_years")
     private Integer experienceYears;  // 경력 년수
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CoverLetterStatus status = CoverLetterStatus.ACTIVE;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
@@ -70,5 +75,15 @@ public class CoverLetter extends BaseTimeEntity {
         this.content = content;
         this.jobField = jobField;
         this.experienceYears = experienceYears;
+    }
+
+    // 소프트 삭제 메서드
+    public void delete() {
+        this.status = CoverLetterStatus.DELETED;
+    }
+
+    // 활성 상태 확인
+    public boolean isActive() {
+        return this.status == CoverLetterStatus.ACTIVE;
     }
 }

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/enums/CoverLetterStatus.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/enums/CoverLetterStatus.java
@@ -1,0 +1,6 @@
+package com.cvmento.domain.coverLetter.enums;
+
+public enum CoverLetterStatus {
+    ACTIVE,    // 활성 (기본값)
+    DELETED    // 삭제됨 (소프트 삭제)
+}

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/repository/CoverLetterRepository.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/repository/CoverLetterRepository.java
@@ -1,6 +1,7 @@
 package com.cvmento.domain.coverLetter.repository;
 
 import com.cvmento.domain.coverLetter.entity.CoverLetter;
+import com.cvmento.domain.coverLetter.enums.CoverLetterStatus;
 import com.cvmento.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,10 +17,12 @@ public interface CoverLetterRepository extends JpaRepository<CoverLetter, Long> 
     List<CoverLetter> findAllByOrderByUpdatedAtDesc();
 
     // 페이징 지원 메서드들
-    Page<CoverLetter> findByMemberOrderByUpdatedAtDesc(Member member, Pageable pageable);
-    Optional<CoverLetter> findByCoverLetterIdAndMember(Long coverLetterId, Member member);
+    Page<CoverLetter> findByMemberAndStatusOrderByUpdatedAtDesc(Member member, CoverLetterStatus status, Pageable pageable);
 
-    @Query("SELECT c FROM CoverLetter c WHERE c.coverLetterId = :coverLetterId AND c.member.email = :userEmail")
-    Optional<CoverLetter> findByCoverLetterIdAndMemberEmail(@Param("coverLetterId") Long coverLetterId,
-                                                            @Param("userEmail") String userEmail);
+    @Query("SELECT c FROM CoverLetter c WHERE c.coverLetterId = :coverLetterId AND c.member.email = :memberEmail AND c.status = :status")
+    Optional<CoverLetter> findByCoverLetterIdAndMemberEmailAndStatus(
+            @Param("coverLetterId") Long coverLetterId,
+            @Param("memberEmail") String memberEmail,
+            @Param("status") CoverLetterStatus status
+    );
 }

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/service/CoverLetterService.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/service/CoverLetterService.java
@@ -5,6 +5,7 @@ import com.cvmento.domain.coverLetter.dto.request.CoverLetterUpdateRequest;
 import com.cvmento.domain.coverLetter.dto.response.CoverLetterDetailResponse;
 import com.cvmento.domain.coverLetter.dto.response.CoverLetterListResponse;
 import com.cvmento.domain.coverLetter.entity.CoverLetter;
+import com.cvmento.domain.coverLetter.enums.CoverLetterStatus;
 import com.cvmento.domain.coverLetter.repository.CoverLetterRepository;
 import com.cvmento.domain.member.entity.Member;
 import com.cvmento.domain.member.repository.MemberRepository;
@@ -33,8 +34,8 @@ public class CoverLetterService {
      * 자소서 저장 (원본/AI첨삭 구분)
      */
     @Transactional
-    public void saveCoverLetter(CoverLetterSaveRequest request, String userEmail) {
-        Member member = findMemberByEmail(userEmail);
+    public void saveCoverLetter(CoverLetterSaveRequest request, String memberEmail) {
+        Member member = findMemberByEmail(memberEmail);
 
         // 제목에 접두사 추가
         String finalTitle = buildTitleWithPrefix(request.title(), request.isAiImproved());
@@ -51,20 +52,20 @@ public class CoverLetterService {
 
         String logType = request.isAiImproved() ? "AI첨삭" : "원본";
         log.info("{} 자소서 저장 완료 - ID: {}, 사용자: {}",
-                logType, savedCoverLetter.getCoverLetterId(), userEmail);
+                logType, savedCoverLetter.getCoverLetterId(), memberEmail);
     }
 
     /**
      * 자소서 수정
      */
     @Transactional
-    public void updateCoverLetter(Long coverLetterId, CoverLetterUpdateRequest request, String userEmail) {
-        CoverLetter coverLetter = findCoverLetterByIdAndUser(coverLetterId, userEmail);
+    public void updateCoverLetter(Long coverLetterId, CoverLetterUpdateRequest request, String memberEmail) {
+        CoverLetter coverLetter = findActiveCoverLetterByIdAndMember(coverLetterId, memberEmail);
 
         // [수정본] 접두사 추가
         String finalTitle = "[수정본] " + request.title();
 
-        // 엔티티 업데이트
+        // 엔티티 업데이트 (updatedAt은 자동으로 갱신됨)
         coverLetter.updateCoverLetter(
                 finalTitle,
                 request.content(),
@@ -73,15 +74,31 @@ public class CoverLetterService {
         );
         coverLetterRepository.save(coverLetter);
 
-        log.info("자소서 수정 완료 - ID: {}, 사용자: {}", coverLetterId, userEmail);
+        log.info("자소서 수정 완료 - ID: {}, 사용자: {}", coverLetterId, memberEmail);
     }
 
     /**
-     * 자소서 목록 조회 (페이징 + view 옵션)
+     * 자소서 삭제 (소프트 삭제)
      */
-    public Page<CoverLetterListResponse> getCoverLetters(String userEmail, Pageable pageable, String view) {
-        Member member = findMemberByEmail(userEmail);
-        Page<CoverLetter> coverLetters = coverLetterRepository.findByMemberOrderByUpdatedAtDesc(member, pageable);
+    @Transactional
+    public void deleteCoverLetter(Long coverLetterId, String memberEmail) {
+        CoverLetter coverLetter = findActiveCoverLetterByIdAndMember(coverLetterId, memberEmail);
+
+        // 소프트 삭제 (상태를 DELETED로 변경)
+        coverLetter.delete();
+
+        log.info("자소서 삭제 완료 - ID: {}, 사용자: {}", coverLetterId, memberEmail);
+    }
+
+    /**
+     * 자소서 목록 조회 (페이징 + view 옵션) - 활성 상태만
+     */
+    public Page<CoverLetterListResponse> getCoverLetters(String memberEmail, Pageable pageable, String view) {
+        Member member = findMemberByEmail(memberEmail);
+
+        // 활성 상태의 자소서만 조회
+        Page<CoverLetter> coverLetters = coverLetterRepository
+                .findByMemberAndStatusOrderByUpdatedAtDesc(member, CoverLetterStatus.ACTIVE, pageable);
 
         boolean isThumbnailView = "thumbnail".equals(view);
 
@@ -93,19 +110,19 @@ public class CoverLetterService {
                 .toList();
 
         log.info("자소서 목록 조회 - 사용자: {}, 페이지: {}, 크기: {}, 뷰: {}, 총 개수: {}",
-                userEmail, pageable.getPageNumber(), pageable.getPageSize(),
+                memberEmail, pageable.getPageNumber(), pageable.getPageSize(),
                 isThumbnailView ? "thumbnail" : "full", coverLetters.getTotalElements());
 
         return new PageImpl<>(responses, pageable, coverLetters.getTotalElements());
     }
 
     /**
-     * 자소서 단일 조회
+     * 자소서 단일 조회 - 활성 상태만
      */
-    public CoverLetterDetailResponse getCoverLetter(Long coverLetterId, String userEmail) {
-        CoverLetter coverLetter = findCoverLetterByIdAndUser(coverLetterId, userEmail);
+    public CoverLetterDetailResponse getCoverLetter(Long coverLetterId, String memberEmail) {
+        CoverLetter coverLetter = findActiveCoverLetterByIdAndMember(coverLetterId, memberEmail);
 
-        log.info("자소서 상세 조회 - ID: {}, 사용자: {}", coverLetterId, userEmail);
+        log.info("자소서 상세 조회 - ID: {}, 사용자: {}", coverLetterId, memberEmail);
 
         return CoverLetterDetailResponse.from(coverLetter);
     }
@@ -122,9 +139,12 @@ public class CoverLetterService {
                 .orElseThrow(() -> new MemberNotFoundException("사용자를 찾을 수 없습니다."));
     }
 
-    private CoverLetter findCoverLetterByIdAndUser(Long coverLetterId, String userEmail) {
-        Member member = findMemberByEmail(userEmail);
-        return coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, member)
+    /**
+     * 활성 상태의 자소서만 조회하는 헬퍼 메서드 (이메일 기반)
+     */
+    private CoverLetter findActiveCoverLetterByIdAndMember(Long coverLetterId, String memberEmail) {
+        return coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                        coverLetterId, memberEmail, CoverLetterStatus.ACTIVE)
                 .orElseThrow(() -> new CoverLetterException("자소서를 찾을 수 없습니다."));
     }
 }

--- a/CVMento/src/main/java/com/cvmento/domain/coverLetter/service/CoverLetterService.java
+++ b/CVMento/src/main/java/com/cvmento/domain/coverLetter/service/CoverLetterService.java
@@ -1,6 +1,7 @@
 package com.cvmento.domain.coverLetter.service;
 
 import com.cvmento.domain.coverLetter.dto.request.CoverLetterSaveRequest;
+import com.cvmento.domain.coverLetter.dto.request.CoverLetterUpdateRequest;
 import com.cvmento.domain.coverLetter.dto.response.CoverLetterDetailResponse;
 import com.cvmento.domain.coverLetter.dto.response.CoverLetterListResponse;
 import com.cvmento.domain.coverLetter.entity.CoverLetter;
@@ -51,6 +52,28 @@ public class CoverLetterService {
         String logType = request.isAiImproved() ? "AI첨삭" : "원본";
         log.info("{} 자소서 저장 완료 - ID: {}, 사용자: {}",
                 logType, savedCoverLetter.getCoverLetterId(), userEmail);
+    }
+
+    /**
+     * 자소서 수정
+     */
+    @Transactional
+    public void updateCoverLetter(Long coverLetterId, CoverLetterUpdateRequest request, String userEmail) {
+        CoverLetter coverLetter = findCoverLetterByIdAndUser(coverLetterId, userEmail);
+
+        // [수정본] 접두사 추가
+        String finalTitle = "[수정본] " + request.title();
+
+        // 엔티티 업데이트
+        coverLetter.updateCoverLetter(
+                finalTitle,
+                request.content(),
+                request.jobField(),
+                request.experienceYears()
+        );
+        coverLetterRepository.save(coverLetter);
+
+        log.info("자소서 수정 완료 - ID: {}, 사용자: {}", coverLetterId, userEmail);
     }
 
     /**

--- a/CVMento/src/main/java/com/cvmento/domain/interview/controller/InterviewController.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/controller/InterviewController.java
@@ -90,8 +90,8 @@ public class InterviewController {
             @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        String userEmail = userDetails.getUsername();
-        InterviewQnaListResponse response = interviewService.getExistingInterviewQna(coverLetterId, userEmail);
+        String memberEmail = userDetails.getUsername();
+        InterviewQnaListResponse response = interviewService.getExistingInterviewQna(coverLetterId, memberEmail);
 
         return ResponseEntity.ok(CommonResponse.success("면접 질문/답변 조회 성공", response));
     }
@@ -180,8 +180,8 @@ public class InterviewController {
             @Parameter(description = "자소서 ID") @PathVariable Long coverLetterId,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        String userEmail = userDetails.getUsername();
-        InterviewQnaListResponse response = interviewService.createInterviewQuestions(coverLetterId, userEmail);
+        String memberEmail = userDetails.getUsername();
+        InterviewQnaListResponse response = interviewService.createInterviewQuestions(coverLetterId, memberEmail);
 
         return ResponseEntity.ok(CommonResponse.success("면접 질문/답변 생성 성공", response));
     }
@@ -262,12 +262,10 @@ public class InterviewController {
             @Valid @RequestBody CustomQuestionRequest request,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        String userEmail = userDetails.getUsername();
+        String memberEmail = userDetails.getUsername();
         CustomAnswerResponse response = interviewService.createCustomAnswer(
-                coverLetterId, userEmail, request.question());
+                coverLetterId, memberEmail, request.question());
 
         return ResponseEntity.ok(CommonResponse.success("커스텀 질문 답변 생성 성공", response));
     }
-
-
 }

--- a/CVMento/src/main/java/com/cvmento/domain/interview/service/InterviewService.java
+++ b/CVMento/src/main/java/com/cvmento/domain/interview/service/InterviewService.java
@@ -1,6 +1,7 @@
 package com.cvmento.domain.interview.service;
 
 import com.cvmento.domain.coverLetter.entity.CoverLetter;
+import com.cvmento.domain.coverLetter.enums.CoverLetterStatus;
 import com.cvmento.domain.coverLetter.repository.CoverLetterRepository;
 import com.cvmento.domain.interview.dto.response.*;
 import com.cvmento.domain.interview.entity.CoverLetterQna;
@@ -35,8 +36,8 @@ public class InterviewService {
     /**
      * 기존 면접 질문/답변 조회 (순수 조회)
      */
-    public InterviewQnaListResponse getExistingInterviewQna(Long coverLetterId, String userEmail) {
-        CoverLetter coverLetter = findCoverLetterByIdAndUser(coverLetterId, userEmail);
+    public InterviewQnaListResponse getExistingInterviewQna(Long coverLetterId, String memberEmail) {
+        CoverLetter coverLetter = findActiveCoverLetterByIdAndMember(coverLetterId, memberEmail);
         List<CoverLetterQna> existingQnaList = coverLetterQnaRepository.findByCoverLetterOrderByCreatedAtAsc(coverLetter);
         return buildQnaListResponse(existingQnaList);
     }
@@ -45,8 +46,8 @@ public class InterviewService {
      * 면접 질문/답변 생성 (초기/추가 자동 판단)
      */
     @Transactional
-    public InterviewQnaListResponse createInterviewQuestions(Long coverLetterId, String userEmail) {
-        CoverLetter coverLetter = findCoverLetterByIdAndUser(coverLetterId, userEmail);
+    public InterviewQnaListResponse createInterviewQuestions(Long coverLetterId, String memberEmail) {
+        CoverLetter coverLetter = findActiveCoverLetterByIdAndMember(coverLetterId, memberEmail);
 
         long existingCount = coverLetterQnaRepository.countByCoverLetterAndSourceType(
                 coverLetter, QuestionSourceType.GENERATED);
@@ -63,8 +64,8 @@ public class InterviewService {
      * 사용자 커스텀 질문에 대한 AI 답변 생성 및 저장
      */
     @Transactional
-    public CustomAnswerResponse createCustomAnswer(Long coverLetterId, String userEmail, String customQuestion) {
-        CoverLetter coverLetter = findCoverLetterByIdAndUser(coverLetterId, userEmail);
+    public CustomAnswerResponse createCustomAnswer(Long coverLetterId, String memberEmail, String customQuestion) {
+        CoverLetter coverLetter = findActiveCoverLetterByIdAndMember(coverLetterId, memberEmail);
 
         // 프롬프트 생성
         String prompt = promptService.buildCustomAnswerPrompt(coverLetter, customQuestion);
@@ -148,8 +149,12 @@ public class InterviewService {
         return new InterviewQnaListResponse(qnaResponses, newQnas.size(), newQnas.size());
     }
 
-    private CoverLetter findCoverLetterByIdAndUser(Long coverLetterId, String userEmail) {
-        return coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail)
+    /**
+     * 활성 상태의 자소서만 조회하는 헬퍼 메서드
+     */
+    private CoverLetter findActiveCoverLetterByIdAndMember(Long coverLetterId, String memberEmail) {
+        return coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                        coverLetterId, memberEmail, CoverLetterStatus.ACTIVE)
                 .orElseThrow(() -> new CoverLetterException("자소서를 찾을 수 없습니다."));
     }
 

--- a/CVMento/src/test/java/com/cvmento/domain/coverLetter/service/CoverLetterServiceTest.java
+++ b/CVMento/src/test/java/com/cvmento/domain/coverLetter/service/CoverLetterServiceTest.java
@@ -1,0 +1,148 @@
+package com.cvmento.domain.coverLetter.service;
+
+import com.cvmento.domain.coverLetter.dto.request.CoverLetterUpdateRequest;
+import com.cvmento.domain.coverLetter.entity.CoverLetter;
+import com.cvmento.domain.coverLetter.repository.CoverLetterRepository;
+import com.cvmento.domain.member.entity.Member;
+import com.cvmento.domain.member.repository.MemberRepository;
+import com.cvmento.global.exception.customException.CoverLetterException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CoverLetterService 단위 테스트")
+class CoverLetterServiceTest {
+
+    @Mock
+    private CoverLetterRepository coverLetterRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private CoverLetterService coverLetterService;
+
+    private Member testMember;
+    private CoverLetter testCoverLetter;
+    private CoverLetterUpdateRequest updateRequest;
+
+    @BeforeEach
+    void setUp() {
+        testMember = new Member("google123", "test@example.com", "테스트유저", "profile.jpg");
+
+        testCoverLetter = new CoverLetter(
+                "[원본] 네이버 백엔드 개발자 지원",
+                "기존 자소서 내용입니다.",
+                "백엔드 개발자",
+                1,
+                testMember
+        );
+
+        updateRequest = new CoverLetterUpdateRequest(
+                "카카오 백엔드 개발자 지원",
+                "수정된 자소서 내용입니다.",
+                "풀스택 개발자",
+                2
+        );
+    }
+
+    @Test
+    @DisplayName("자소서 수정 성공 - 정상 케이스")
+    void updateCoverLetter_Success() {
+        // given
+        String userEmail = "test@example.com";
+        Long coverLetterId = 1L;
+
+        given(memberRepository.findByEmail(userEmail))
+                .willReturn(Optional.of(testMember));
+        given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, testMember))
+                .willReturn(Optional.of(testCoverLetter));
+
+        // when
+        coverLetterService.updateCoverLetter(coverLetterId, updateRequest, userEmail);
+
+        // then
+        assertThat(testCoverLetter.getTitle()).isEqualTo("[수정본] 카카오 백엔드 개발자 지원");
+        assertThat(testCoverLetter.getContent()).isEqualTo("수정된 자소서 내용입니다.");
+        assertThat(testCoverLetter.getJobField()).isEqualTo("풀스택 개발자");
+        assertThat(testCoverLetter.getExperienceYears()).isEqualTo(2);
+    }
+
+
+
+    @Test
+    @DisplayName("자소서 수정 실패 - 존재하지 않는 자소서")
+    void updateCoverLetter_Fail_CoverLetterNotFound() {
+        // given
+        String userEmail = "test@example.com";
+        Long coverLetterId = 999L;
+
+        given(memberRepository.findByEmail(userEmail))
+                .willReturn(Optional.of(testMember));
+        given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, testMember))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                coverLetterService.updateCoverLetter(coverLetterId, updateRequest, userEmail))
+                .isInstanceOf(CoverLetterException.class)
+                .hasMessage("자소서를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("자소서 수정 실패 - 다른 사용자의 자소서 수정 시도")
+    void updateCoverLetter_Fail_UnauthorizedAccess() {
+        // given
+        String hackerEmail = "hacker@example.com";
+        Long coverLetterId = 1L;
+
+        // 해커(다른 사용자) 생성
+        Member hackerMember = new Member("google456", hackerEmail, "해커", "hacker.jpg");
+
+        given(memberRepository.findByEmail(hackerEmail))
+                .willReturn(Optional.of(hackerMember));
+
+        // 해커가 testMember의 자소서를 조회하려 하지만 권한이 없어서 조회 안됨
+        given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, hackerMember))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                coverLetterService.updateCoverLetter(coverLetterId, updateRequest, hackerEmail))
+                .isInstanceOf(CoverLetterException.class)
+                .hasMessage("자소서를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("[수정본] 접두사가 올바르게 추가되는지 확인")
+    void updateCoverLetter_TitlePrefix() {
+        // given
+        String userEmail = "test@example.com";
+        Long coverLetterId = 1L;
+
+        given(memberRepository.findByEmail(userEmail))
+                .willReturn(Optional.of(testMember));
+        given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, testMember))
+                .willReturn(Optional.of(testCoverLetter));
+
+        CoverLetterUpdateRequest requestWithShortTitle = new CoverLetterUpdateRequest(
+                "단순제목", "내용", "직무", 1
+        );
+
+        // when
+        coverLetterService.updateCoverLetter(coverLetterId, requestWithShortTitle, userEmail);
+
+        // then
+        assertThat(testCoverLetter.getTitle()).isEqualTo("[수정본] 단순제목");
+    }
+}

--- a/CVMento/src/test/java/com/cvmento/domain/coverLetter/service/CoverLetterServiceTest.java
+++ b/CVMento/src/test/java/com/cvmento/domain/coverLetter/service/CoverLetterServiceTest.java
@@ -2,6 +2,7 @@ package com.cvmento.domain.coverLetter.service;
 
 import com.cvmento.domain.coverLetter.dto.request.CoverLetterUpdateRequest;
 import com.cvmento.domain.coverLetter.entity.CoverLetter;
+import com.cvmento.domain.coverLetter.enums.CoverLetterStatus;
 import com.cvmento.domain.coverLetter.repository.CoverLetterRepository;
 import com.cvmento.domain.member.entity.Member;
 import com.cvmento.domain.member.repository.MemberRepository;
@@ -60,16 +61,16 @@ class CoverLetterServiceTest {
     @DisplayName("자소서 수정 성공 - 정상 케이스")
     void updateCoverLetter_Success() {
         // given
-        String userEmail = "test@example.com";
+        String memberEmail = "test@example.com";
         Long coverLetterId = 1L;
 
-        given(memberRepository.findByEmail(userEmail))
-                .willReturn(Optional.of(testMember));
-        given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, testMember))
+        // 변경: 이메일과 상태로 직접 조회하는 방식으로 Mock 설정
+        given(coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                coverLetterId, memberEmail, CoverLetterStatus.ACTIVE))
                 .willReturn(Optional.of(testCoverLetter));
 
         // when
-        coverLetterService.updateCoverLetter(coverLetterId, updateRequest, userEmail);
+        coverLetterService.updateCoverLetter(coverLetterId, updateRequest, memberEmail);
 
         // then
         assertThat(testCoverLetter.getTitle()).isEqualTo("[수정본] 카카오 백엔드 개발자 지원");
@@ -78,23 +79,21 @@ class CoverLetterServiceTest {
         assertThat(testCoverLetter.getExperienceYears()).isEqualTo(2);
     }
 
-
-
     @Test
     @DisplayName("자소서 수정 실패 - 존재하지 않는 자소서")
     void updateCoverLetter_Fail_CoverLetterNotFound() {
         // given
-        String userEmail = "test@example.com";
+        String memberEmail = "test@example.com";
         Long coverLetterId = 999L;
 
-        given(memberRepository.findByEmail(userEmail))
-                .willReturn(Optional.of(testMember));
-        given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, testMember))
+        // 변경: 이메일과 상태로 직접 조회하는 방식으로 Mock 설정
+        given(coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                coverLetterId, memberEmail, CoverLetterStatus.ACTIVE))
                 .willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() ->
-                coverLetterService.updateCoverLetter(coverLetterId, updateRequest, userEmail))
+                coverLetterService.updateCoverLetter(coverLetterId, updateRequest, memberEmail))
                 .isInstanceOf(CoverLetterException.class)
                 .hasMessage("자소서를 찾을 수 없습니다.");
     }
@@ -106,14 +105,10 @@ class CoverLetterServiceTest {
         String hackerEmail = "hacker@example.com";
         Long coverLetterId = 1L;
 
-        // 해커(다른 사용자) 생성
-        Member hackerMember = new Member("google456", hackerEmail, "해커", "hacker.jpg");
-
-        given(memberRepository.findByEmail(hackerEmail))
-                .willReturn(Optional.of(hackerMember));
-
-        // 해커가 testMember의 자소서를 조회하려 하지만 권한이 없어서 조회 안됨
-        given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, hackerMember))
+        // 변경: Member 엔티티 생성 불필요, 이메일로 직접 조회
+        // 해커가 다른 사람의 자소서를 조회하려 하지만 권한이 없어서 조회 안됨
+        given(coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                coverLetterId, hackerEmail, CoverLetterStatus.ACTIVE))
                 .willReturn(Optional.empty());
 
         // when & then
@@ -127,12 +122,12 @@ class CoverLetterServiceTest {
     @DisplayName("[수정본] 접두사가 올바르게 추가되는지 확인")
     void updateCoverLetter_TitlePrefix() {
         // given
-        String userEmail = "test@example.com";
+        String memberEmail = "test@example.com";
         Long coverLetterId = 1L;
 
-        given(memberRepository.findByEmail(userEmail))
-                .willReturn(Optional.of(testMember));
-        given(coverLetterRepository.findByCoverLetterIdAndMember(coverLetterId, testMember))
+        // 변경: 이메일과 상태로 직접 조회하는 방식으로 Mock 설정
+        given(coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                coverLetterId, memberEmail, CoverLetterStatus.ACTIVE))
                 .willReturn(Optional.of(testCoverLetter));
 
         CoverLetterUpdateRequest requestWithShortTitle = new CoverLetterUpdateRequest(
@@ -140,7 +135,7 @@ class CoverLetterServiceTest {
         );
 
         // when
-        coverLetterService.updateCoverLetter(coverLetterId, requestWithShortTitle, userEmail);
+        coverLetterService.updateCoverLetter(coverLetterId, requestWithShortTitle, memberEmail);
 
         // then
         assertThat(testCoverLetter.getTitle()).isEqualTo("[수정본] 단순제목");

--- a/CVMento/src/test/java/com/cvmento/domain/interview/service/InterviewServiceTest.java
+++ b/CVMento/src/test/java/com/cvmento/domain/interview/service/InterviewServiceTest.java
@@ -1,6 +1,7 @@
 package com.cvmento.domain.interview.service;
 
 import com.cvmento.domain.coverLetter.entity.CoverLetter;
+import com.cvmento.domain.coverLetter.enums.CoverLetterStatus;
 import com.cvmento.domain.coverLetter.repository.CoverLetterRepository;
 import com.cvmento.domain.interview.dto.response.CustomAnswerResponse;
 import com.cvmento.domain.interview.dto.response.InterviewLlmResponse;
@@ -59,13 +60,13 @@ class InterviewServiceTest {
     private Member testMember;
     private CoverLetter testCoverLetter;
     private Long coverLetterId = 1L;
-    private String userEmail = "test@example.com";
+    private String memberEmail = "test@example.com";
 
     @BeforeEach
     void setUp() throws Exception {
         log.info("=== 테스트 데이터 설정 시작 ===");
 
-        testMember = new Member("google123", userEmail, "테스트 사용자", "profile.jpg");
+        testMember = new Member("google123", memberEmail, "테스트 사용자", "profile.jpg");
         setField(testMember, "memberId", 1L);
         log.info("테스트 Member 생성 완료: email={}, name={}, memberId={}",
                 testMember.getEmail(), testMember.getName(), 1L);
@@ -98,11 +99,12 @@ class InterviewServiceTest {
             List<CoverLetterQna> existingQnas = createMockQnaList(5);
             log.info("생성된 가짜 질문 개수: {}", existingQnas.size());
 
-            // 실제 서비스 로직에 맞춘 Mock 설정
-            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
+            // 수정된 Mock 설정: 상태 조건 추가
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                    coverLetterId, memberEmail, CoverLetterStatus.ACTIVE))
                     .willReturn(Optional.of(testCoverLetter));
-            log.info("Mock 설정: coverLetterRepository.findByCoverLetterIdAndMemberEmail({}, {}) -> testCoverLetter 반환",
-                    coverLetterId, userEmail);
+            log.info("Mock 설정: coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus({}, {}, ACTIVE) -> testCoverLetter 반환",
+                    coverLetterId, memberEmail);
 
             given(coverLetterQnaRepository.findByCoverLetterOrderByCreatedAtAsc(testCoverLetter))
                     .willReturn(existingQnas);
@@ -111,7 +113,7 @@ class InterviewServiceTest {
 
             // when
             log.info("=== 메서드 실행 ===");
-            InterviewQnaListResponse result = interviewService.getExistingInterviewQna(coverLetterId, userEmail);
+            InterviewQnaListResponse result = interviewService.getExistingInterviewQna(coverLetterId, memberEmail);
             log.info("메서드 실행 결과: qnaList.size()={}, totalCount={}, generatedCount={}",
                     result.qnaList().size(), result.totalCount(), result.generatedCount());
 
@@ -135,14 +137,15 @@ class InterviewServiceTest {
             log.info("=== 테스트 시작: 기존 질문이 없을 때 빈 배열 반환 ===");
 
             // given
-            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                    coverLetterId, memberEmail, CoverLetterStatus.ACTIVE))
                     .willReturn(Optional.of(testCoverLetter));
             given(coverLetterQnaRepository.findByCoverLetterOrderByCreatedAtAsc(testCoverLetter))
                     .willReturn(new ArrayList<>());
             log.info("Mock 설정: 빈 배열 반환하도록 설정");
 
             // when
-            InterviewQnaListResponse result = interviewService.getExistingInterviewQna(coverLetterId, userEmail);
+            InterviewQnaListResponse result = interviewService.getExistingInterviewQna(coverLetterId, memberEmail);
             log.info("메서드 실행 결과: qnaList.size()={}, totalCount={}, generatedCount={}",
                     result.qnaList().size(), result.totalCount(), result.generatedCount());
 
@@ -160,15 +163,16 @@ class InterviewServiceTest {
             log.info("=== 테스트 시작: 존재하지 않는 자소서일 때 예외 발생 ===");
 
             // given
-            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                    coverLetterId, memberEmail, CoverLetterStatus.ACTIVE))
                     .willReturn(Optional.empty());
-            log.info("Mock 설정: coverLetterRepository.findByCoverLetterIdAndMemberEmail({}, {}) -> Optional.empty() 반환",
-                    coverLetterId, userEmail);
+            log.info("Mock 설정: coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus({}, {}, ACTIVE) -> Optional.empty() 반환",
+                    coverLetterId, memberEmail);
 
             // when & then
             log.info("예외 발생 예상 - CoverLetterException");
             assertThatThrownBy(() ->
-                    interviewService.getExistingInterviewQna(coverLetterId, userEmail))
+                    interviewService.getExistingInterviewQna(coverLetterId, memberEmail))
                     .isInstanceOf(CoverLetterException.class)
                     .hasMessage("자소서를 찾을 수 없습니다.");
             log.info("✅ 예상된 예외 발생 확인");
@@ -183,9 +187,10 @@ class InterviewServiceTest {
         @BeforeEach
         void setUp() {
             log.info("--- CreateInterviewQuestionsTest 공통 Mock 설정 ---");
-            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                    coverLetterId, memberEmail, CoverLetterStatus.ACTIVE))
                     .willReturn(Optional.of(testCoverLetter));
-            log.info("CoverLetter 조회 Mock 설정 완료\n");
+            log.info("CoverLetter 조회 Mock 설정 완료 (상태 조건 포함)\n");
         }
 
         @Test
@@ -215,7 +220,7 @@ class InterviewServiceTest {
 
             // when
             log.info("=== 메서드 실행 ===");
-            InterviewQnaListResponse result = interviewService.createInterviewQuestions(coverLetterId, userEmail);
+            InterviewQnaListResponse result = interviewService.createInterviewQuestions(coverLetterId, memberEmail);
 
             // then
             log.info("=== 결과 검증 ===");
@@ -281,7 +286,7 @@ class InterviewServiceTest {
 
             // when
             log.info("=== 메서드 실행 ===");
-            InterviewQnaListResponse result = interviewService.createInterviewQuestions(coverLetterId, userEmail);
+            InterviewQnaListResponse result = interviewService.createInterviewQuestions(coverLetterId, memberEmail);
 
             // then
             log.info("=== 결과 검증 ===");
@@ -317,7 +322,7 @@ class InterviewServiceTest {
             // when & then
             log.info("예외 발생 예상 - InterviewLimitExceededException");
             assertThatThrownBy(() ->
-                    interviewService.createInterviewQuestions(coverLetterId, userEmail))
+                    interviewService.createInterviewQuestions(coverLetterId, memberEmail))
                     .isInstanceOf(InterviewLimitExceededException.class)
                     .hasMessage("더 이상 질문을 생성할 수 없습니다. (최대 15개)");
             log.info("✅ 예상된 제한 초과 예외 발생 확인");
@@ -353,7 +358,7 @@ class InterviewServiceTest {
             // when & then
             log.info("예외 발생 예상 - InterviewException");
             assertThatThrownBy(() ->
-                    interviewService.createInterviewQuestions(coverLetterId, userEmail))
+                    interviewService.createInterviewQuestions(coverLetterId, memberEmail))
                     .isInstanceOf(InterviewException.class)
                     .hasMessage("질문/답변 생성에 실패했습니다.");
             log.info("✅ 예상된 InterviewException 발생 확인");
@@ -372,9 +377,10 @@ class InterviewServiceTest {
         @BeforeEach
         void setUp() {
             log.info("--- CreateCustomAnswerTest 공통 Mock 설정 ---");
-            given(coverLetterRepository.findByCoverLetterIdAndMemberEmail(coverLetterId, userEmail))
+            given(coverLetterRepository.findByCoverLetterIdAndMemberEmailAndStatus(
+                    coverLetterId, memberEmail, CoverLetterStatus.ACTIVE))
                     .willReturn(Optional.of(testCoverLetter));
-            log.info("CoverLetter 조회 Mock 설정 완료\n");
+            log.info("CoverLetter 조회 Mock 설정 완료 (상태 조건 포함)\n");
         }
 
         @Test
@@ -404,7 +410,7 @@ class InterviewServiceTest {
 
             // when
             log.info("=== 메서드 실행 ===");
-            CustomAnswerResponse result = interviewService.createCustomAnswer(coverLetterId, userEmail, customQuestion);
+            CustomAnswerResponse result = interviewService.createCustomAnswer(coverLetterId, memberEmail, customQuestion);
 
             // then
             log.info("=== 결과 검증 ===");
@@ -468,7 +474,7 @@ class InterviewServiceTest {
             // when & then
             log.info("예외 발생 예상 - InterviewException");
             assertThatThrownBy(() ->
-                    interviewService.createCustomAnswer(coverLetterId, userEmail, customQuestion))
+                    interviewService.createCustomAnswer(coverLetterId, memberEmail, customQuestion))
                     .isInstanceOf(InterviewException.class)
                     .hasMessage("커스텀 질문 답변 생성에 실패했습니다.");
             log.info("✅ 예상된 InterviewException 발생 확인");


### PR DESCRIPTION
- 자소서 수정/삭제 기능 추가
- 변수명이 member가 아닌 user로 사용한 부분들 추가 수정
- 소프트 삭제를 위해 자소서의 상태값을 추가하며, 생성시에는 ACTIVE, 삭제 후에는 DELETED로 수정되게함
- 이에 따라, 자소서를 조회하는 로직에는 전부 상태값을 걸도록 수정
- 또한 관련된 메서드를 사용하는 테스트 코드 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 자소서 수정 및 삭제 기능을 추가했습니다.
  - 소프트 삭제를 도입해 삭제된 자소서는 목록과 상세에서 보이지 않습니다.
  - 조회 기능이 활성 상태의 자소서만 반환하도록 개선되었습니다.
- Documentation
  - API 문서에 수정·삭제 및 상태 동작에 대한 설명을 보강했습니다.
- Refactor
  - 사용자 식별자 명칭을 일관되게 정리했습니다.
- Tests
  - 자소서 수정, 상태 기반 조회, 예외 케이스에 대한 단위 테스트를 추가·보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->